### PR TITLE
Rename SsrfSocketsHttpHanderFactory (missing L)

### DIFF
--- a/demo/ConsoleDemo/Program.cs
+++ b/demo/ConsoleDemo/Program.cs
@@ -137,7 +137,7 @@ static async Task TestWithHttpClient(string uri, bool allowInsecureProtocols = f
     string errorMessage = string.Empty;
 
     using (var httpClient = new HttpClient(
-        SsrfSocketsHttpHanderFactory.Create(
+        SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: null,
@@ -223,7 +223,7 @@ static async Task TestWithClientWebSocket(string uri, bool allowInsecureProtocol
     string errorMessage = string.Empty;
 
     using (var clientWebSocket = new ClientWebSocket())
-    using (var invoker = new HttpClient(SsrfSocketsHttpHanderFactory.Create(
+    using (var invoker = new HttpClient(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: null,
@@ -300,7 +300,7 @@ static async Task TestWithClientWebSocket(string uri, bool allowInsecureProtocol
                     errorMessage = $"{ex.GetType().Name} => {innerException.GetType().Name}: {innerException.Message}";
                 }
             }
-          
+
         }
         catch (TaskCanceledException ex)
         {

--- a/demo/DelegatingHttpHandler/Program.cs
+++ b/demo/DelegatingHttpHandler/Program.cs
@@ -9,7 +9,7 @@ using DelegatingHttpHandler;
 
 var timingHandler = new TimingHandler()
 {
-    InnerHandler = SsrfSocketsHttpHanderFactory.Create(
+    InnerHandler = SsrfSocketsHttpHandlerFactory.Create(
          connectionStrategy: ConnectionStrategy.None,
          additionalUnsafeNetworks: null,
          additionalUnsafeIpAddresses: null,
@@ -31,7 +31,7 @@ using (var httpClient = new HttpClient(timingHandler))
 
 timingHandler = new TimingHandler()
 {
-    InnerHandler = SsrfSocketsHttpHanderFactory.Create(
+    InnerHandler = SsrfSocketsHttpHandlerFactory.Create(
          connectionStrategy: ConnectionStrategy.None,
          additionalUnsafeNetworks: null,
          additionalUnsafeIpAddresses: [

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ pass an instance of the handler in the constructor to add the handler to the mes
 
 ```c#
 using (var httpClient = new HttpClient(
-    SsrfSocketsHttpHanderFactory.Create(connectTimeout: new TimeSpan(0, 0, 5))))
+    SsrfSocketsHttpHandlerFactory.Create(connectTimeout: new TimeSpan(0, 0, 5))))
 {
     _ = await httpClient.GetAsync(new Uri("bad.ssl.fail")).ConfigureAwait(false);
 }
@@ -29,7 +29,7 @@ If you want to protect a `ClientWebSocket` you pass a an instance of the handler
 ```c#
 using (var webSocket = new ClientWebSocket())
 using (var invoker = new HttpClient(
-    SsrfSocketsHttpHanderFactory.Create()))
+    SsrfSocketsHttpHandlerFactory.Create()))
 {
     await webSocket.ConnectAsync(
         uri: new Uri("wss://echo.websocket.org"),
@@ -40,13 +40,13 @@ using (var invoker = new HttpClient(
 If the SSRF handler finds an unsafe host, or a host that resolves to an IP unsafe address it will throw an `SsrfException`.
 
 If the SSRF handler finds an unsafe protocol, (i.e. http://, ws://) it will throw an `SsrfException`, unless
-the `allowInsecureProtocols` parameter is set to `true` when calling `SsrfSocketsHttpHanderFactory.Create()`.
+the `allowInsecureProtocols` parameter is set to `true` when calling `SsrfSocketsHttpHandlerFactory.Create()`.
 It will always throw when it encounters an non-HTTP/HTTPS/WS/WSS protocol, even if `allowInsecureProtocols` is set to `true`.
 
 Extra unsafe IP address ranges can be provided using the `additionalUnsafeNetworks` parameter.
 
 If the SSRF handler finds a mixture of safe and unsafe IP addresses for a host it will throw an `SsrfException` unless the
-`failMixedResults` parameter is set to `false` when calling `SsrfSocketsHttpHanderFactory.Create()`.
+`failMixedResults` parameter is set to `false` when calling `SsrfSocketsHttpHandlerFactory.Create()`.
 If `failMixedResults` is set to `false` then the handler will allow the request to proceed to any safe IP addresses
 discovered during DNS resolution, and will ignore any unsafe IP addresses discovered.
 This is not recommended, but it is provided as an option for scenarios where a host may legitimately
@@ -79,7 +79,7 @@ if (idunno.Security.Ssrf.IsUnsafeIpAddress(IPAddress.Parse("127.0.0.1")))
 
 If you want to perform both checks you can use the `IsUnsafe` method, which will check both the URI and the resolved IP addresses.
 
-Note these checks are performed within `SsrfSocketsHttpHanderFactory.Create()` during the creation of an outgoing connection,
+Note these checks are performed within `SsrfSocketsHttpHandlerFactory.Create()` during the creation of an outgoing connection,
 so you don't need to call them yourself if you're using the handler.
 
 **DO NOT** solely rely on the `IsUnsafeUri` method for validating URIs. This would create a Time of Check /

--- a/src/idunno.Security.Ssrf/SsrfOptions.cs
+++ b/src/idunno.Security.Ssrf/SsrfOptions.cs
@@ -7,7 +7,7 @@ using System.Net.Security;
 namespace idunno.Security;
 
 /// <summary>
-/// Encapsulates options for the <see cref="SsrfSocketsHttpHanderFactory"/>.
+/// Encapsulates options for the <see cref="SsrfSocketsHttpHandlerFactory"/>.
 /// </summary>
 public record SsrfOptions
 {

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -12,12 +12,12 @@ namespace idunno.Security;
 /// <summary>
 /// Contains helper methods for validating URIs and IP addresses to mitigate SSRF (Server-Side Request Forgery) vulnerabilities.
 /// </summary>
-public sealed class SsrfSocketsHttpHanderFactory
+public sealed class SsrfSocketsHttpHandlerFactory
 {
     private static readonly Func<string, CancellationToken, Task<IPHostEntry>> s_defaultHostEntryResolver = Dns.GetHostEntryAsync;
 
     [ExcludeFromCodeCoverage]
-    private SsrfSocketsHttpHanderFactory()
+    private SsrfSocketsHttpHandlerFactory()
     {
     }
 
@@ -853,7 +853,7 @@ public sealed class SsrfSocketsHttpHanderFactory
     {
         hostEntryResolver ??= s_defaultHostEntryResolver;
         loggerFactory ??= NullLoggerFactory.Instance;
-        ILogger logger = loggerFactory.CreateLogger<SsrfSocketsHttpHanderFactory>();
+        ILogger logger = loggerFactory.CreateLogger<SsrfSocketsHttpHandlerFactory>();
 
         SocketsHttpHandler handler = new()
         {
@@ -929,7 +929,7 @@ public sealed class SsrfSocketsHttpHanderFactory
 #pragma warning restore S3267
 
                 // If no safe IP addresses remain after filtering, block the connection as all resolved addresses are unsafe.
-                // If some safe addresses remain but others were filtered out as unsafe, the behavior will depend on the value of the failMixedResults flag. 
+                // If some safe addresses remain but others were filtered out as unsafe, the behavior will depend on the value of the failMixedResults flag.
                 if (safeResolvedIPAddresses.Count == 0)
                 {
                     Log.AllResolvedIpAddressesUnsafe(logger, requestedUri);
@@ -989,7 +989,7 @@ public sealed class SsrfSocketsHttpHanderFactory
                         throw;
                     }
                 }
-                
+
                 Log.HostUnreachable(logger, requestedUri);
                 throw new SocketException((int)SocketError.HostUnreachable);
             }

--- a/src/idunno.Security.Ssrf/readme.md
+++ b/src/idunno.Security.Ssrf/readme.md
@@ -14,7 +14,7 @@ Add the `idunno.Security.Ssrf` package to your project, and then when you create
 to the message handler pipeline.
 
 ```c#
-using (var httpClient = new HttpClient(idunno.Security.SsrfSocketsHttpHanderFactory.Create()))   
+using (var httpClient = new HttpClient(idunno.Security.SsrfSocketsHttpHandlerFactory.Create()))
 {
     _ = await httpClient.GetAsync(new Uri("bad.ssl.fail")).ConfigureAwait(false);
 }
@@ -26,7 +26,7 @@ If you want to protect a `ClientWebSocket` you can pass a an instance of the han
 ```c#
 
 using (var webSocket = new ClientWebSock())
-using (var httpClient = new HttpClient(idunno.Security.SsrfSocketsHttpHanderFactory.Create()))
+using (var httpClient = new HttpClient(idunno.Security.SsrfSocketsHttpHandlerFactory.Create()))
 {
     await webSocket.ConnectAsync(
         uri: new Uri("wss://echo.websocket.org"),

--- a/test/idunno.Security.SsrfTests/HttpClientTests.cs
+++ b/test/idunno.Security.SsrfTests/HttpClientTests.cs
@@ -16,7 +16,7 @@ public class HttpClientTests
     [InlineData("https://bad.ipv6.ssrf.fail/")]
     public async Task ConnectionThrowsForUnsafeUri(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(connectTimeout: new TimeSpan(0,0,5)));
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(connectTimeout: new TimeSpan(0,0,5)));
         HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(async () => _ = await httpClient.GetAsync(hostName, cancellationToken: TestContext.Current.CancellationToken));
 
         Exception? innermostException = ex;
@@ -40,7 +40,7 @@ public class HttpClientTests
     [InlineData("https://mixed.ipv6.ssrf.fail/")]
     public async Task ConnectionThrowsForHostsThatReturnAMixOfSafeAndUnsafeIPAddresses(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(connectTimeout: new TimeSpan(0, 0, 5)));
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(connectTimeout: new TimeSpan(0, 0, 5)));
         try
         {
             _ = await httpClient.GetAsync(hostName, cancellationToken: TestContext.Current.CancellationToken);
@@ -74,7 +74,7 @@ public class HttpClientTests
     [InlineData("https://mixed.ipv6.ssrf.fail/")]
     public async Task ConnectionContinuesForHostsThatReturnAMixOfSafeAndUnsafeIPAddressesIfFailMixedResultsIsFalse(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: null,
@@ -119,7 +119,7 @@ public class HttpClientTests
     [InlineData("https://github.com/")]
     public async Task ConnectionSucceedsForSafeUri(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(connectTimeout: new TimeSpan(0, 0, 5)));
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(connectTimeout: new TimeSpan(0, 0, 5)));
         HttpResponseMessage response = await httpClient.GetAsync(hostName, cancellationToken: TestContext.Current.CancellationToken);
         Assert.True(response.IsSuccessStatusCode);
     }
@@ -129,7 +129,7 @@ public class HttpClientTests
     [InlineData("http://github.com/")]
     public async Task ConnectionThrowsForSafeHostButUnsafeProtocol(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create());
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create());
         HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(async () => _ = await httpClient.GetAsync(hostName, cancellationToken: TestContext.Current.CancellationToken));
         Exception? innermostException = ex;
         while (innermostException.InnerException is not null)
@@ -151,7 +151,7 @@ public class HttpClientTests
     [InlineData("http://github.com/")]
     public async Task ConnectionThrowsForSafeHostButUnsafeProtocolIfAllowInsecureProtocolIsTrue(string hostName)
     {
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: null,
@@ -179,7 +179,7 @@ public class HttpClientTests
             };
         }
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: [IPAddress.Parse("1.2.3.4")],
@@ -221,7 +221,7 @@ public class HttpClientTests
             };
         }
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: null,
             additionalUnsafeIpAddresses: [IPAddress.Parse("2606:4700::6812:1b78")],
@@ -263,7 +263,7 @@ public class HttpClientTests
             };
         }
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: [IPNetwork.Parse("1.2.3.0/24")],
             additionalUnsafeIpAddresses: null,
@@ -305,7 +305,7 @@ public class HttpClientTests
             };
         }
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: [IPNetwork.Parse("2620:1ec::/36")],
             additionalUnsafeIpAddresses: null,
@@ -361,7 +361,7 @@ public class HttpClientTests
             SslOptions = null
         };
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(options));
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(options));
         HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(async () => _ = await httpClient.GetAsync("https://example.org", cancellationToken: TestContext.Current.CancellationToken));
         Exception? innermostException = ex;
         while (innermostException.InnerException is not null)
@@ -388,7 +388,7 @@ public class HttpClientTests
             return new IPHostEntry();
         }
 
-        using HttpClient httpClient = new(SsrfSocketsHttpHanderFactory.Create(
+        using HttpClient httpClient = new(SsrfSocketsHttpHandlerFactory.Create(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeNetworks: [IPNetwork.Parse("2620:1ec::/36")],
             additionalUnsafeIpAddresses: null,


### PR DESCRIPTION
Minor spelling correction: SsrfSocketsHttpHanderFactory renamed SsrfSocketsHttpHandlerFactory.

As per contributing guidelines, not bothering to open an issue for a minor spelling issue.