### PR TITLE
Dev/v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 * Add Azure WireServer IP range.
 * Add AMT/Global-Unicast range.
 * Add AS112 ranges.
-* Add Depreacted Anycast Prefix for 6to4 Relay Routers.
+* Add Deprecated Anycast Prefix for 6to4 Relay Routers.
 * Add IPv6 discard/dummy range.
 * Add Segment Routing (SRv6) SIDs range.
-* Add tests for the specifc ranges [AntiSSRF](https://github.com/microsoft/AntiSSRF/blob/main/config/IPAddressRanges.json) uses.
+* Add tests for the specific ranges [AntiSSRF](https://github.com/microsoft/AntiSSRF/blob/main/config/IPAddressRanges.json) uses.
 
 ### Changed
 
-* Stubbed the dns resolver for mixed.ipv6.ssrf.fail tests because corpnet is being very odd with that host.
+* Stubbed the DNS resolver for mixed.ipv6.ssrf.fail tests because corpnet is being very odd with that host.
 
 ## 5.1.0 - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Changed
 
 * Stubbed the DNS resolver for mixed.ipv6.ssrf.fail tests because some corporate DNS servers can be flakey with that host, so
-the tests are now deterministic.
+  the tests are now deterministic.
 
 ## 5.1.0 - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 5.2.0 - Unreleased
+
+### Added
+
+* Add Azure WireServer IP range.
+* Add AMT/Global-Unicast range.
+* Add AS112 ranges.
+* Add Depreacted Anycast Prefix for 6to4 Relay Routers.
+* Add IPv6 discard/dummy range.
+* Add Segment Routing (SRv6) SIDs range.
+* Add tests for the specifc ranges [AntiSSRF](https://github.com/microsoft/AntiSSRF/blob/main/config/IPAddressRanges.json) uses.
+
+### Changed
+
+* Stubbed the dns resolver for mixed.ipv6.ssrf.fail tests because corpnet is being very odd with that host.
+
 ## 5.1.0 - 2026-04-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changed
 
-* Stubbed the DNS resolver for mixed.ipv6.ssrf.fail tests because corpnet is being very odd with that host.
+* Stubbed the DNS resolver for mixed.ipv6.ssrf.fail tests because some corporate DNS servers can be flakey with that host, so
+the tests are now deterministic.
 
 ## 5.1.0 - 2026-04-30
 

--- a/readme.md
+++ b/readme.md
@@ -181,3 +181,7 @@ The package source URI is https://www.myget.org/F/blowdart/api/v3/index.json
 * [ReportGenerator](https://github.com/danielpalme/ReportGenerator) - used to produce code coverage reports.
 * [sign](https://github.com/dotnet/sign) - used to code sign assemblies and nuget packages.
 * [xunit](https://github.com/xunit/xunit) - used for unit tests.
+
+## Other .NET SSRF Mitigation Libraries
+
+* [Microsoft AntiSSRF](https://github.com/microsoft/AntiSSRF/).

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Security;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -98,9 +98,13 @@ public static class Ssrf
             new (IPAddress.Parse("100::"), 64),
 
             // GLOBAL-UNICAST (reserved for AMT) https://datatracker.ietf.org/doc/html/rfc7450
+            // Whilst this is already covered in the IETF Protocol Assignments block above, this specific /32 has a well known unsafe meaning,
+            // and is duplicated here for clarity and to catch any future changes to the larger block that might remove this range.
             new (IPAddress.Parse("2001:3::"), 32),
 
             // AS112 https://datatracker.ietf.org/doc/html/rfc7534
+            // Whilst this is already covered in the IETF Protocol Assignments block above, this specific /48 has a well known unsafe meaning,
+            // and is duplicated here for clarity and to catch any future changes to the larger block that might remove this range.
             new (IPAddress.Parse("2001:4:112::"), 48),
             new (IPAddress.Parse("2620:4f:8000::"), 48),
 

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -104,10 +104,10 @@ public static class Ssrf
             new (IPAddress.Parse("2001:4:112::"), 48),
             new (IPAddress.Parse("2620:4f:8000::"), 48),
 
-            // Discard addresses https://datatracker.ietf.org/doc/html/rfc6666
+            //  IPv6 dummy address prefix https://datatracker.ietf.org/doc/html/rfc6666
             new (IPAddress.Parse("100:0:0:1::"), 64),
 
-            // Segment Routing (SRv6) SIDs https://datatracker.ietf.org/doc/rfc9602/ / https://www.ietf.org/archive/id/draft-ek-srv6ops-sidspace-experiment-00.html
+            // Segment Routing (SRv6) SIDs https://datatracker.ietf.org/doc/rfc9602/, https://www.ietf.org/archive/id/draft-ek-srv6ops-sidspace-experiment-00.html
             new (IPAddress.Parse("5f00::"), 16)
         ];
 

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -45,7 +45,20 @@ public static class Ssrf
             // IPv4 multicast https://datatracker.ietf.org/doc/html/rfc1112
             new(IPAddress.Parse("224.0.0.0"), 4),
             // IPv4 reserved https://datatracker.ietf.org/doc/html/rfc1112
-            new(IPAddress.Parse("240.0.0.0"), 4)
+            new(IPAddress.Parse("240.0.0.0"), 4),
+
+            // Azure WireServer https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+            new (IPAddress.Parse("168.63.129.16"), 32),
+
+            // GLOBAL-UNICAST (reserved for AMT) https://datatracker.ietf.org/doc/html/rfc7450
+            new (IPAddress.Parse("192.52.193.0"), 24),
+
+            // AS112 https://datatracker.ietf.org/doc/html/rfc7534
+            new (IPAddress.Parse("192.31.196.0"), 24),
+            new (IPAddress.Parse("192.175.48.0"), 24),
+
+            // Deprecated "limited broadcast" range https://www.rfc-editor.org/rfc/rfc7526
+            new (IPAddress.Parse("192.88.99.0"), 24)
         ];
 
     private static readonly IPNetwork[] s_ipv6UnsafeRanges =
@@ -82,7 +95,20 @@ public static class Ssrf
 
             // IPv6 discard-only prefix https://datatracker.ietf.org/doc/html/rfc6666
             // while this range silently drops traffic so there is no SSRF risk, blocking it prevents potential connection-hanging probes.
-            new (IPAddress.Parse("100::"), 64)
+            new (IPAddress.Parse("100::"), 64),
+
+            // GLOBAL-UNICAST (reserved for AMT) https://datatracker.ietf.org/doc/html/rfc7450
+            new (IPAddress.Parse("2001:3::"), 32),
+
+            // AS112 https://datatracker.ietf.org/doc/html/rfc7534
+            new (IPAddress.Parse("2001:4:112::"), 48),
+            new (IPAddress.Parse("2620:4f:8000::"), 48),
+
+            // Discard addresses https://datatracker.ietf.org/doc/html/rfc6666
+            new (IPAddress.Parse("100:0:0:1::"), 64),
+
+            // Segment Routing (SRv6) SIDs https://datatracker.ietf.org/doc/html/rfc4291
+            new (IPAddress.Parse("5f00::"), 16)
         ];
 
     /// <summary>

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -57,7 +57,7 @@ public static class Ssrf
             new (IPAddress.Parse("192.31.196.0"), 24),
             new (IPAddress.Parse("192.175.48.0"), 24),
 
-            // Deprecated 6to4 relay anycast prefix" range https://www.rfc-editor.org/rfc/rfc7526
+            // Deprecated 6to4 relay anycast prefix range https://www.rfc-editor.org/rfc/rfc7526
             new (IPAddress.Parse("192.88.99.0"), 24)
         ];
 

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -57,7 +57,7 @@ public static class Ssrf
             new (IPAddress.Parse("192.31.196.0"), 24),
             new (IPAddress.Parse("192.175.48.0"), 24),
 
-            // Deprecated "limited broadcast" range https://www.rfc-editor.org/rfc/rfc7526
+            // Deprecated 6to4 relay anycast prefix" range https://www.rfc-editor.org/rfc/rfc7526
             new (IPAddress.Parse("192.88.99.0"), 24)
         ];
 
@@ -107,7 +107,7 @@ public static class Ssrf
             // Discard addresses https://datatracker.ietf.org/doc/html/rfc6666
             new (IPAddress.Parse("100:0:0:1::"), 64),
 
-            // Segment Routing (SRv6) SIDs https://datatracker.ietf.org/doc/html/rfc4291
+            // Segment Routing (SRv6) SIDs https://datatracker.ietf.org/doc/rfc9602/ / https://www.ietf.org/archive/id/draft-ek-srv6ops-sidspace-experiment-00.html
             new (IPAddress.Parse("5f00::"), 16)
         ];
 

--- a/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
+++ b/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
@@ -365,4 +365,299 @@ public class IsUnsafeIpAddress
             safeIPAddresses: null,
             allowLoopback: false));
     }
+
+    // The following tests match the naming of blocks by the Azure Anti-SSRF team
+    // in their code, https://github.com/microsoft/AntiSSRF.
+    // While it does duplicate some of the tests above, it also makes for
+    // an easier comparison to ensure that all of the same blocks are included in this implementation.
+
+    [Fact]
+    public void ReturnsTrueForAzureWireServerIpAddresses()
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse("168.63.129.16")));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.11")]
+    [InlineData("2001:0001:0000:0000:0000:0000:0000:0001")]
+    public void ReturnsTrueForNATAnyCast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.52.193.1")]
+    [InlineData("192.52.193.254")]
+    [InlineData("2001:0003:0000:0000:0000:0000:0000:0001")]
+    [InlineData("2001:0003:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForAmt(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.31.196.1")]
+    [InlineData("192.31.196.254")]
+    [InlineData("192.175.48.1")]
+    [InlineData("192.175.48.254")]
+    [InlineData("2001:4:112::1")]
+    [InlineData("2001:4:112::ff")]
+    [InlineData("2620:4f:8000::1")]
+    [InlineData("2620:4f:8000::ff")]
+    public void ReturnsTrueForAS112(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.88.99.1")]
+    [InlineData("192.88.99.254")]
+    [InlineData("2001:10::1")]
+    [InlineData("2001:10::ff")]
+    public void ReturnsTrueForDeprecatedIpAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("2001:30::1")]
+    [InlineData("2001:30::ff")]
+    public void ReturnsTrueForDroneRemoteIDProtocolEntityTagsPrefix(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("100::1")]
+    [InlineData("100::ff")]
+    public void ReturnsTrueForDiscardOnly(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Fact]
+    public void ReturnsTrueForAnyCast()
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse("2001:0001:0000:0000:0000:0000:0000:0003")));
+    }
+
+    [Theory]
+    [InlineData("192.0.2.1")]
+    [InlineData("192.0.2.254")]
+    [InlineData("198.51.100.1")]
+    [InlineData("198.51.100.254")]
+    [InlineData("203.0.113.1")]
+    [InlineData("203.0.113.254")]
+    [InlineData("2001:db8::1")]
+    [InlineData("2001:db8::ff")]
+    [InlineData("3fff::1")]
+    [InlineData("3fff::ff")]
+    public void ReturnsTrueForDocumentationIPAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.8")]
+    [InlineData("100:0:0:1::1")]
+    [InlineData("0100:0000:0000:0001:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForDummyAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.1")]
+    [InlineData("192.0.0.254")]
+    [InlineData("2001:0000:0000:0000:0000:0000:0000:0000")]
+    [InlineData("2001:01ff:ffff:ffff:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForProtocolAssignments(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.1")]
+    [InlineData("192.0.0.254")]
+    [InlineData("2001:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("2001:01ff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForIETFProtocolAssignmentAddresses(string ipaddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipaddressAsString)));
+    }
+
+    [Fact]
+    public void ReturnsTrueForInstanceMetadataService()
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse("169.254.169.254")));
+    }
+
+    [Theory]
+    [InlineData("0064:ff9b:0000:0000:0000:0000:0000:0001")]
+    [InlineData("0064:ff9b:0000:0000:0000:0000:ffff:ffff")]
+    [InlineData("0064:ff9b:0001:0000:0000:0000:0000:0000")]
+    [InlineData("0064:ff9b:0001:ffff:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForIPv4IPv6Translated(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.1")]
+    [InlineData("192.0.0.6")]
+    public void ReturnsTrueForIpv4ContinuityPrefix(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Fact]
+    public void ReturnsTrueForLimitedBroadcastAddresses()
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse("255.255.255.255")));
+    }
+
+    [Theory]
+    [InlineData("169.254.0.1")]
+    [InlineData("169.254.255.254")]
+    [InlineData("fe80:0000:0000:0000:0000:0000:0000:0000")]
+    [InlineData("febf:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForLinkLocal(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.255.255.254")]
+    [InlineData("0000:0000:0000:0000:0000:0000:0000:0001")]
+    public void ReturnsTrueForLoopback(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("224.0.0.1")]
+    [InlineData("239.255.255.254")]
+    [InlineData("ff00:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForMulticast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.170")]
+    [InlineData("192.0.0.171")]
+    public void ReturnsTrueForNat64Dns64Discovery(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("2001:0020:0000:0000:0000:0000:0000:0001")]
+    [InlineData("2001:002f:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForORCHIDv2Addresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.9")]
+    [InlineData("2001:1::1")]
+    public void ReturnsTrueForPCPAnycast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("10.0.0.1")]
+    [InlineData("10.255.255.254")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.254")]
+    [InlineData("192.168.0.1")]
+    [InlineData("192.168.255.254")]
+    public void ReturnsTrueForPrivateUseAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("240.0.0.1")]
+    [InlineData("255.255.255.254")]
+    public void ReturnsTrueForReservedAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("100.64.0.1")]
+    [InlineData("100.127.255.254")]
+    public void ReturnsTrueForSharedAddressSpace(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("fec0:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("feff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForSiteLocal(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.88.99.2")]
+    public void ReturnsTrueForSix4aaRelayAnycast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("2002:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("2002:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForSixtoFour(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("5f00:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("5f00:ffff:ffff:ffff:ffff:ffff:ffff:fffe")]
+    public void ReturnsTrueForSegmentRoutingSIDs(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("2001:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("2001:0000:ffff:ffff:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForTeradoAddresses(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("192.0.0.10")]
+    [InlineData("2001:0001:0000:0000:0000:0000:0000:0002")]
+    public void ReturnsTrueForNATAnycast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("fc00:0000:0000:0000:0000:0000:0000:0001")]
+    [InlineData("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
+    public void ReturnsTrueForUniqueLocalUnicast(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
+
+    [Theory]
+    [InlineData("0.0.0.1")]
+    [InlineData("0.255.255.254")]
+    // Note ::/128 is an invalid IP address 
+    public void ReturnsTrueForThisHostUnspecifiedNetwork(string ipAddressAsString)
+    {
+        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
+    }
 }

--- a/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
+++ b/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
@@ -631,7 +631,7 @@ public class IsUnsafeIpAddress
     [Theory]
     [InlineData("2001:0000:0000:0000:0000:0000:0000:0001")]
     [InlineData("2001:0000:ffff:ffff:ffff:ffff:ffff:ffff")]
-    public void ReturnsTrueForTeradoAddresses(string ipAddressAsString)
+    public void ReturnsTrueForTeredoAddresses(string ipAddressAsString)
     {
         Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
     }
@@ -655,7 +655,7 @@ public class IsUnsafeIpAddress
     [Theory]
     [InlineData("0.0.0.1")]
     [InlineData("0.255.255.254")]
-    // Note ::/128 is an invalid IP address 
+    // Note ::/128 from the AntiSSRF list is not an actual IP address, but rather a network containing only the unspecified IPv6 address.
     public void ReturnsTrueForThisHostUnspecifiedNetwork(string ipAddressAsString)
     {
         Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));

--- a/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
+++ b/test/idunno.Security.SsrfTests/IsUnsafeIpAddress.cs
@@ -637,14 +637,6 @@ public class IsUnsafeIpAddress
     }
 
     [Theory]
-    [InlineData("192.0.0.10")]
-    [InlineData("2001:0001:0000:0000:0000:0000:0000:0002")]
-    public void ReturnsTrueForNATAnycast(string ipAddressAsString)
-    {
-        Assert.True(Ssrf.IsUnsafeIpAddress(IPAddress.Parse(ipAddressAsString)));
-    }
-
-    [Theory]
     [InlineData("fc00:0000:0000:0000:0000:0000:0000:0001")]
     [InlineData("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
     public void ReturnsTrueForUniqueLocalUnicast(string ipAddressAsString)

--- a/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
+++ b/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
@@ -83,10 +83,51 @@ public class ProxiedSsrfDelegatingHandler
     [InlineData("https://mixed.ipv6.ssrf.fail/")]
     public async Task ConnectionContinuesForHostsThatReturnAMixOfSafeAndUnsafeIPAddressesIfFailMixedResultsIsFalse(string hostName)
     {
+        static async Task<IPHostEntry> asyncHostEntryResolver(string uri, CancellationToken cancellationToken)
+        {
+            return new IPHostEntry
+            {
+                HostName = uri,
+                AddressList = [
+                    IPAddress.Parse("2001:db8::1"),
+                    IPAddress.Parse("2606:4700:4700::1111"),
+                    IPAddress.Parse("fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
+                ]
+            };
+        }
+
+        static IPHostEntry hostEntryResolver(string uri)
+        {
+            return new IPHostEntry
+            {
+                HostName = uri,
+                AddressList = [
+                    IPAddress.Parse("2001:db8::1"),
+                    IPAddress.Parse("2606:4700:4700::1111"),
+                    IPAddress.Parse("fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
+                ]
+            };
+        }
+
         using var proxiedSsrfDelegatingHandler = new Security.ProxiedSsrfDelegatingHandler(
+            proxy: new WebProxy(new Uri("http://127.0.0.1:9999")),
+            connectionStrategy: ConnectionStrategy.None,
+            additionalUnsafeIPNetworks: null,
+            additionalUnsafeIPAddresses: null,
+            allowedHostnames: null,
+            safeIPNetworks: null,
+            safeIPAddresses: null,
             connectTimeout: TimeSpan.FromSeconds(1),
+            allowedSchemes: [ "https" ],
+            allowLoopback: false,
             failMixedResults: false,
-            proxy: new WebProxy(new Uri("http://127.0.0.1:9999")));
+            allowAutoRedirect: false,
+            automaticDecompression: null,
+            sslOptions: null,
+            hostEntryResolver: hostEntryResolver,
+            asyncHostEntryResolver: asyncHostEntryResolver,
+            loggerFactory: null,
+            meterFactory: null);
         using HttpClient httpClient = new(proxiedSsrfDelegatingHandler);
         Exception? ex = await Record.ExceptionAsync(async () => await httpClient.GetAsync(hostName, cancellationToken: TestContext.Current.CancellationToken));
 

--- a/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
+++ b/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
@@ -218,6 +218,7 @@ public class ProxiedSsrfDelegatingHandler
             };
         }
 
+
         static async Task<IPHostEntry> asyncHostEntryResolver(string uri, CancellationToken cancellationToken)
         {
             return new IPHostEntry

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -74,17 +74,38 @@ public class SsrfSocketsHttpHandlerFactory
     [InlineData("https://mixed.ipv6.ssrf.fail/")]
     public async Task ConnectionContinuesForHostsThatReturnAMixOfSafeAndUnsafeIPAddressesIfFailMixedResultsIsFalse(string uri)
     {
-        using HttpClient httpClient = new(Security.SsrfSocketsHttpHandlerFactory.Create(
+        static async Task<IPHostEntry> asyncHostEntryResolver(string uri, CancellationToken cancellationToken)
+        {
+            return new IPHostEntry
+            {
+                HostName = uri,
+                AddressList = [
+                    IPAddress.Parse("2001:db8::1"),
+                    IPAddress.Parse("2606:4700:4700::1111"),
+                    IPAddress.Parse("fdff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
+                ]
+            };
+        }
+
+
+        using HttpClient httpClient = new(Security.SsrfSocketsHttpHandlerFactory.InternalCreate(
             connectionStrategy: ConnectionStrategy.None,
             additionalUnsafeIPNetworks: null,
             additionalUnsafeIPAddresses: null,
+            allowedHostnames: null,
+            safeIPNetworks: null,
+            safeIPAddresses: null,
             connectTimeout: new TimeSpan(0,0,1),
             allowedSchemes: null,
             allowLoopback: false,
             failMixedResults: false,
             allowAutoRedirect: false,
             automaticDecompression: null,
-            sslOptions: null));
+            proxy: null,
+            sslOptions: null,
+            asyncHostEntryResolver: asyncHostEntryResolver,
+            loggerFactory: null,
+            meterFactory: null));
 
         try
         {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "5.1.0",
+    "version": "5.2.0",
     "publicReleaseRefSpec": [
         "^refs\/heads\/main\/.*$"
     ],


### PR DESCRIPTION
* Add Azure WireServer IP range.
* Add AMT/Global-Unicast range.
* Add AS112 ranges.
* Add Depreacted Anycast Prefix for 6to4 Relay Routers.
* Add IPv6 discard/dummy range.
* Add Segment Routing (SRv6) SIDs range.
* Add tests for the specifc ranges [AntiSSRF](https://github.com/microsoft/AntiSSRF/blob/main/config/IPAddressRanges.json) uses.
