### PR TITLE
Dev/v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
 * Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
-* Add documentation warnings to configuration for hostnames
+* Add documentation warnings to configuration for allowedHostnames.
 * Add a TOCTOU warning to `Ssrf.IsUnsafe` documentation.
 
 ## 5.2.0 - 2026-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-* Skip allowedHostname checks for ip literal hosts, as they're not a host name.
+* Skip allowedHostname checks for IP literal hosts, as they're not a host name.
 * Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
 * Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
 * Add documentation warnings to configuration for hostnames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
 * Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
 * Add documentation warnings to configuration for hostnames
-* Add a TOCTOU warnings warning to `Ssrf.IsUnsafe` documentation.
+* Add a TOCTOU warning to `Ssrf.IsUnsafe` documentation.
 
 ## 5.2.0 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 
 * Skip allowedHostname checks for ip literal hosts, as they're not a host name.
+* Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
+* Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
 * Add documentation warnings to configuration for hostnames
 * Add documentation warnings about TOCTOU warning to `Ssrf.IsUnsafe`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
 * Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
 * Add documentation warnings to configuration for hostnames
-* Add documentation warnings about TOCTOU warning to `Ssrf.IsUnsafe`
+* Add a TOCTOU warnings warning to `Ssrf.IsUnsafe` documentation.
 
 ## 5.2.0 - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Changed
 
-* Skip allowedHostname checks for IP literal hosts, as they're not a host name.
 * Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
 * Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
 * Add documentation warnings to configuration for hostnames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.3.0 - Unreleased
+
+### Changed
+
+* Skip allowedHostname checks for ip literal hosts, as they're not a host name.
+* Add documentation warnings to configuration for hostnames
+* Add documentation warnings about TOCTOU warning to `Ssrf.IsUnsafe`
+
 ## 5.2.0 - 2026-05-07
 
 ### Added

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -39,12 +39,24 @@ a range of services within a trusted domain without having to list each one indi
 apply to the leftmost part of the hostname, so `*.example.localhost` would match `service1.example.localhost`
 and `live.database.example.localhost`, but not `example.localhost` itself.
 
+>! [!Warning]
+> Specifying a hostname or wildcard pattern in allowedHostnames will allow that
+> hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+> Take care when using this setting to only allow specific trusted hostnames or patterns.
+> Only specify a hostname under your control.
+> Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+> *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+> register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+> obtain a full SSRF.
+
 ## Safe listing IP addresses and networks
 
 The `safeIPAddresses` and `safeIPNetworks` parameters allow you to specify individual IP addresses and networks
 that are safe to connect to, even if they would normally be considered unsafe.
 This is useful for cases where you have a known safe IP address or network that may fall within an unsafe range,
 such as a local development environment or a trusted internal service.
+
+Add additional entries in normalized IPv4 form for IPv4-embedded IPv6 addresses or networks.
 
 > [!Warning]
 > Careless use of `safeIPNetworks` and `safeIPAddresses` can lead to security vulnerabilities by allowing

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -39,9 +39,9 @@ a range of services within a trusted domain without having to list each one indi
 apply to the leftmost part of the hostname, so `*.example.localhost` would match `service1.example.localhost`
 and `live.database.example.localhost`, but not `example.localhost` itself.
 
->! [!Warning]
+> [!Warning]
 > Specifying a hostname or wildcard pattern in allowedHostnames will allow that
-> hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+> hostname to bypass the checks for unsafe IP addresses.
 > Take care when using this setting to only allow specific trusted hostnames or patterns.
 > Only specify a hostname under your control.
 > Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -34,7 +34,7 @@ This is useful for cases where you have a known safe host that may resolve to an
 or a trusted internal service.
 
 `allowedHostnames` supports wildcard patterns, so you can specify a pattern like `*.example.localhost`
-to allow all subdomains of `example.localhost`.This can be particularly useful for allowing access to
+to allow all subdomains of `example.localhost`. This can be particularly useful for allowing access to
 a range of services within a trusted domain without having to list each one individually. Wildcard patterns only
 apply to the leftmost part of the hostname, so `*.example.localhost` would match `service1.example.localhost`
 and `live.database.example.localhost`, but not `example.localhost` itself.

--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -38,11 +38,7 @@ internal static class CommonFunctions
         {
             resolvedIpAddresses = await GetHostEntryAsync(uri, logger, asyncHostEntryResolver, cancellationToken).ConfigureAwait(false);
 
-            // Ignore IP literal hosts for the hostname check as these should be added
-            // via safeIPNetworks or safeIPAddresses
-            if (uri.HostNameType != UriHostNameType.IPv4 &&
-                uri.HostNameType != UriHostNameType.IPv6 &&
-                Ssrf.IsInAllowedHostnames(uri, allowedHostnames))
+            if (Ssrf.IsInAllowedHostnames(uri, allowedHostnames))
             {
                 Log.ChecksBypassedForAllowedHostnames(logger, uri);
                 return resolvedIpAddresses;
@@ -91,14 +87,14 @@ internal static class CommonFunctions
             {
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, uri.Host, ex);
-                throw new SsrfException(uri, "Connection blocked as host could not be resolved.", inner: ex);
+                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved.", inner: ex);
             }
         }
 
         if (resolvedIpAddresses.Length == 0)
         {
             Log.DnsResolutionFailed(logger, uri.Host);
-            throw new SsrfException(uri, "Connection blocked as host could not be resolved to any IP addresses.");
+            throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved to any IP addresses.");
         }
 
         return resolvedIpAddresses;
@@ -137,17 +133,17 @@ internal static class CommonFunctions
                 try
                 {
                     Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-                    throw new SsrfException(uri, "Connection blocked as host could not be resolved.", inner: ex);
+                    throw new SsrfException(uri, $"Connection blocked as {host} could not be resolved.", inner: ex);
                 }
                 catch (UriFormatException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, "Connection blocked as host could not be resolved.", inner: ex);
+                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.", inner: ex);
                 }
                 catch (ArgumentException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, "Connection blocked as host could not be resolved.", inner: ex);
+                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.", inner: ex);
                 }
             }
         }
@@ -158,17 +154,17 @@ internal static class CommonFunctions
             try
             {
                 Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-                throw new SsrfException(uri, "Connection blocked as host could not be resolved to any IP addresses.");
+                throw new SsrfException(uri, $"Connection blocked as {host} could not be resolved to any IP addresses.");
             }
             catch (UriFormatException)
             {
                 // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                throw new SsrfException(null, "Connection blocked as host could not be resolved.");
+                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.");
             }
             catch (ArgumentException)
             {
                 // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                throw new SsrfException(null, "Connection blocked as host could not be resolved.");
+                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.");
             }
         }
 
@@ -203,14 +199,14 @@ internal static class CommonFunctions
             {
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, uri.Host, ex);
-                throw new SsrfException(uri, "Connection blocked as host could not be resolved.", inner: ex);
+                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved.", inner: ex);
             }
         }
 
         if (resolvedIpAddresses.Length == 0)
         {
             Log.DnsResolutionFailed(logger, uri.Host);
-            throw new SsrfException(uri, "Connection blocked as host could not be resolved to any IP addresses.");
+            throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved to any IP addresses.");
         }
 
         return resolvedIpAddresses;
@@ -304,7 +300,7 @@ internal static class CommonFunctions
         {
             Log.AllResolvedIpAddressesUnsafe(logger, uri);
             metrics?.IncrementUnsafeIPAddress(1, "all_resolved_addresses_unsafe");
-            throw new SsrfException(uri, "Connection blocked as all resolved addresses are unsafe.");
+            throw new SsrfException(uri, $"Connection blocked as all resolved addresses for {uri.Host} are unsafe.");
         }
 
         // If failMixedResults is set to true, block the connection if any unsafe addresses were found, even if some safe addresses remain.
@@ -314,7 +310,7 @@ internal static class CommonFunctions
         {
             Log.SomeResolvedIpAddressesUnsafe(logger, uri);
             metrics?.IncrementUnsafeIPAddress(1, "some_resolved_addresses_unsafe");
-            throw new SsrfException(uri, "Connection blocked as some resolved addresses are unsafe.");
+            throw new SsrfException(uri, $"Connection blocked as some resolved addresses for {uri.Host} are unsafe.");
         }
 
         return [.. safeResolvedIPAddresses];

--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -27,27 +27,39 @@ internal static class CommonFunctions
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(uri);
-        IPAddress[] resolvedIpAddresses = await GetHostEntryAsync(uri, logger, asyncHostEntryResolver, cancellationToken).ConfigureAwait(false);
 
-        if (Ssrf.IsInAllowedHostnames(uri, allowedHostnames))
+        IPAddress[] resolvedIpAddresses;
+
+        if (uri.HostNameType == UriHostNameType.IPv4 || uri.HostNameType == UriHostNameType.IPv6)
         {
-            Log.ChecksBypassedForAllowedHostnames(logger, uri);
-            return resolvedIpAddresses;
+            resolvedIpAddresses = [IPAddress.Parse(uri.Host)];
         }
         else
         {
-            return ReduceResolvedIPAddressesToSafeIPAddresses(
-                uri: uri,
-                resolvedIpAddresses: resolvedIpAddresses,
-                additionalUnsafeIPNetworks: additionalUnsafeIPNetworks,
-                additionalUnsafeIPAddresses: additionalUnsafeIPAddresses,
-                safeIPNetworks: safeIPNetworks,
-                safeIPAddresses: safeIPAddresses,
-                allowLoopback: allowLoopback,
-                failMixedResults: failMixedResults,
-                logger: logger,
-                metrics: metrics);
+            resolvedIpAddresses = await GetHostEntryAsync(uri, logger, asyncHostEntryResolver, cancellationToken).ConfigureAwait(false);
+
+            // Ignore IP literal hosts for the hostname check as these should be added
+            // via safeIPNetworks or safeIPAddresses
+            if (uri.HostNameType != UriHostNameType.IPv4 &&
+                uri.HostNameType != UriHostNameType.IPv6 &&
+                Ssrf.IsInAllowedHostnames(uri, allowedHostnames))
+            {
+                Log.ChecksBypassedForAllowedHostnames(logger, uri);
+                return resolvedIpAddresses;
+            }
         }
+
+        return ReduceResolvedIPAddressesToSafeIPAddresses(
+            uri: uri,
+            resolvedIpAddresses: resolvedIpAddresses,
+            additionalUnsafeIPNetworks: additionalUnsafeIPNetworks,
+            additionalUnsafeIPAddresses: additionalUnsafeIPAddresses,
+            safeIPNetworks: safeIPNetworks,
+            safeIPAddresses: safeIPAddresses,
+            allowLoopback: allowLoopback,
+            failMixedResults: failMixedResults,
+            logger: logger,
+            metrics: metrics);
     }
 
     internal static async Task<IPAddress[]> GetHostEntryAsync(
@@ -122,16 +134,42 @@ internal static class CommonFunctions
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, host, ex);
 
-                Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-                throw new SsrfException(uri, "Connection blocked as host could not be resolved.", inner: ex);
+                try
+                {
+                    Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
+                    throw new SsrfException(uri, "Connection blocked as host could not be resolved.", inner: ex);
+                }
+                catch (UriFormatException)
+                {
+                    // If the host is not a valid URI host, we can still throw the exception without the URI information.
+                    throw new SsrfException(null, "Connection blocked as host could not be resolved.", inner: ex);
+                }
+                catch (ArgumentException)
+                {
+                    // If the host is not a valid URI host, we can still throw the exception without the URI information.
+                    throw new SsrfException(null, "Connection blocked as host could not be resolved.", inner: ex);
+                }
             }
         }
 
         if (resolvedIpAddresses.Length == 0)
         {
             Log.DnsResolutionFailed(logger, host);
-            Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-            throw new SsrfException(uri, "Connection blocked as host could not be resolved to any IP addresses.");
+            try
+            {
+                Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
+                throw new SsrfException(uri, "Connection blocked as host could not be resolved to any IP addresses.");
+            }
+            catch (UriFormatException)
+            {
+                // If the host is not a valid URI host, we can still throw the exception without the URI information.
+                throw new SsrfException(null, "Connection blocked as host could not be resolved.");
+            }
+            catch (ArgumentException)
+            {
+                // If the host is not a valid URI host, we can still throw the exception without the URI information.
+                throw new SsrfException(null, "Connection blocked as host could not be resolved.");
+            }
         }
 
         return resolvedIpAddresses;

--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -199,7 +199,7 @@ internal static class CommonFunctions
             {
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, uri.Host, ex);
-                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved to any IP addresses.", inner: ex);
+                throw new SsrfException(uri, $"Connection was blocked as an exception was thrown when resolving {uri.Host}.", inner: ex);
             }
         }
 

--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -87,7 +87,7 @@ internal static class CommonFunctions
             {
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, uri.Host, ex);
-                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved.", inner: ex);
+                throw new SsrfException(uri, $"Connection was blocked as an exception was thrown when resolving {uri.Host}.", inner: ex);
             }
         }
 
@@ -133,17 +133,17 @@ internal static class CommonFunctions
                 try
                 {
                     Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-                    throw new SsrfException(uri, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
+                    throw new SsrfException(uri, $"Connection was blocked as an exception was thrown when resolving {host}.", inner: ex);
                 }
                 catch (UriFormatException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
+                    throw new SsrfException(null, $"Connection was blocked as an exception was thrown when resolving {host}.", inner: ex);
                 }
                 catch (ArgumentException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
+                    throw new SsrfException(null, $"Connection was blocked as an exception was thrown when resolving {host}.", inner: ex);
                 }
             }
         }

--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -133,17 +133,17 @@ internal static class CommonFunctions
                 try
                 {
                     Uri uri = new UriBuilder() { Host = host }.Uri; // Create a URI with the host for the exception, even though we don't have a full URI to work with.
-                    throw new SsrfException(uri, $"Connection blocked as {host} could not be resolved.", inner: ex);
+                    throw new SsrfException(uri, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
                 }
                 catch (UriFormatException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.", inner: ex);
+                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
                 }
                 catch (ArgumentException)
                 {
                     // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.", inner: ex);
+                    throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.", inner: ex);
                 }
             }
         }
@@ -159,12 +159,12 @@ internal static class CommonFunctions
             catch (UriFormatException)
             {
                 // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.");
+                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.");
             }
             catch (ArgumentException)
             {
                 // If the host is not a valid URI host, we can still throw the exception without the URI information.
-                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved.");
+                throw new SsrfException(null, $"Connection blocked as {host} could not be resolved to any IP addresses.");
             }
         }
 
@@ -199,7 +199,7 @@ internal static class CommonFunctions
             {
                 // Some DNS proxies or internal servers may already strip dangerous lookups, so if the host cannot be resolved, we can treat it as unsafe and block the connection.
                 Log.DnsResolutionException(logger, uri.Host, ex);
-                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved.", inner: ex);
+                throw new SsrfException(uri, $"Connection blocked as {uri.Host} could not be resolved to any IP addresses.", inner: ex);
             }
         }
 

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -206,7 +206,7 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
             sslOptions: sslOptions,
             asyncHostEntryResolver: _asyncHostEntryResolver,
             loggerFactory: loggerFactory,
-            meterFactory: meterFactory); 
+            meterFactory: meterFactory);
     }
 
     internal ProxiedSsrfDelegatingHandler(
@@ -341,18 +341,18 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
 
         try
         {
-        _ = CommonFunctions.ResolveAndReturnSafeIPAddresses(
-            uri: requestedUri,
-            additionalUnsafeIPNetworks: _additionalUnsafeIPNetworks,
-            additionalUnsafeIPAddresses: _additionalUnsafeIPAddresses,
-            allowedHostnames: _allowedHostnames,
-            safeIPNetworks: _safeIPNetworks,
-            safeIPAddresses: _safeIPAddresses,
-            allowLoopback: _allowLoopback,
-            failMixedResults: _failMixedResults,
-            logger: _logger,
-            metrics: _metrics,
-            hostEntryResolver: _hostEntryResolver);
+            _ = CommonFunctions.ResolveAndReturnSafeIPAddresses(
+                uri: requestedUri,
+                additionalUnsafeIPNetworks: _additionalUnsafeIPNetworks,
+                additionalUnsafeIPAddresses: _additionalUnsafeIPAddresses,
+                allowedHostnames: _allowedHostnames,
+                safeIPNetworks: _safeIPNetworks,
+                safeIPAddresses: _safeIPAddresses,
+                allowLoopback: _allowLoopback,
+                failMixedResults: _failMixedResults,
+                logger: _logger,
+                metrics: _metrics,
+                hostEntryResolver: _hostEntryResolver);
         }
         catch (SsrfException)
         {

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -173,6 +173,8 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
             throw new ArgumentException("The WebProxy instance must have a non-null Address property.", nameof(proxy));
         }
 
+        Ssrf.ValidateAllowedHostnamePatterns(allowedHostnames, nameof(allowedHostnames));
+
         _additionalUnsafeIPNetworks = additionalUnsafeIPNetworks != null ? [.. additionalUnsafeIPNetworks] : null;
         _additionalUnsafeIPAddresses = additionalUnsafeIPAddresses != null ? [.. additionalUnsafeIPAddresses] : null;
         _allowedHostnames = allowedHostnames != null ? [.. allowedHostnames] : null;
@@ -219,6 +221,8 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(options.Proxy);
         ArgumentNullException.ThrowIfNull(options.Proxy.Address);
+
+        Ssrf.ValidateAllowedHostnamePatterns(options.AllowedHostnames, nameof(options));
 
         // Snapshot all the collection based settings to ignore any mutation after the handler has been constructed.
         _additionalUnsafeIPNetworks = options.AdditionalUnsafeIPNetworks != null ? [.. options.AdditionalUnsafeIPNetworks] : null;

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.Metrics;
+using System.Drawing;
 using System.Net;
 using System.Net.Security;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Win32;
 
 namespace idunno.Security;
 
@@ -42,8 +44,7 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
     /// <param name="additionalUnsafeIPNetworks">An optional collection of additional <see cref="IPNetwork"/> ranges to consider unsafe. This can be used to block additional IP ranges beyond the built-in defaults, such as internal application IP ranges or other known unsafe addresses.</param>
     /// <param name="additionalUnsafeIPAddresses">An optional collection of additional <see cref="IPAddress"/> addresses to consider unsafe. This can be used to block additional IP addresses beyond the built-in defaults, such as internal application IP addresses or other known unsafe addresses.</param>
     /// <param name="allowedHostnames">
-    ///     An optional collection of hostnames that are allowed to bypass SSRF IP address protections.
-    ///     This can be used to allow specific trusted hosts names.
+    ///     An optional collection of hostnames that will bypass all SSRF checks.
     ///     Wild cards are supported only at the start of the hostname, and must be followed by a dot
     ///     (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </param>
@@ -62,10 +63,22 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
     /// <exception cref="ArgumentException">Thrown if the provided <paramref name="proxy"/> contains an invalid proxy configuration.</exception>
     /// <remarks>
     /// <para>
+    ///   Specifying a hostname or wildcard pattern in <paramref name="allowedHostnames"/> will allow that
+    ///    hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+    ///    Take care when using this setting to only allow specific trusted hostnames or patterns.
+    ///    Only specify a hostname under your control.
+    ///    Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+    ///    *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+    ///    register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+    ///    obtain a full SSRF.
+    /// </para>
+    /// <para>
     ///   Careless use of <paramref name="safeIPNetworks"/> and <paramref name="safeIPAddresses"/> can lead to security vulnerabilities by allowing potentially unsafe IP addresses or networks
     ///   to be considered safe. Use with caution and constrain the values specified to the smallest network range or individual IP addresses needed.
     ///   Safe entries take precedence over both built-in and additional unsafe entries, so if an IP address matches both a safe and unsafe address, or is within a safe network,
     ///   it will be considered safe.
+    ///
+    ///   Add additional entries in normalized IPv4 form for IPv4-embedded IPv6 addresses or networks.
     ///</para>
     /// </remarks>
     public ProxiedSsrfDelegatingHandler(
@@ -160,11 +173,11 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
             throw new ArgumentException("The WebProxy instance must have a non-null Address property.", nameof(proxy));
         }
 
-        _additionalUnsafeIPNetworks = additionalUnsafeIPNetworks;
-        _additionalUnsafeIPAddresses = additionalUnsafeIPAddresses;
-        _allowedHostnames = allowedHostnames;
-        _safeIPNetworks = safeIPNetworks;
-        _safeIPAddresses = safeIPAddresses;
+        _additionalUnsafeIPNetworks = additionalUnsafeIPNetworks != null ? [.. additionalUnsafeIPNetworks] : null;
+        _additionalUnsafeIPAddresses = additionalUnsafeIPAddresses != null ? [.. additionalUnsafeIPAddresses] : null;
+        _allowedHostnames = allowedHostnames != null ? [.. allowedHostnames] : null;
+        _safeIPNetworks = safeIPNetworks != null ? [.. safeIPNetworks] : null;
+        _safeIPAddresses = safeIPAddresses != null ? [.. safeIPAddresses] : null;
         _allowedSchemes = allowedSchemes != null ? [.. allowedSchemes] : Defaults.AllowedSchemes;
         _allowLoopback = allowLoopback;
         _failMixedResults = failMixedResults;
@@ -207,14 +220,13 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
         ArgumentNullException.ThrowIfNull(options.Proxy);
         ArgumentNullException.ThrowIfNull(options.Proxy.Address);
 
-        ICollection<string>? snapshotAllowedSchemes = options.AllowedSchemes is null ? null : [.. options.AllowedSchemes];
-
-        _additionalUnsafeIPNetworks = options.AdditionalUnsafeIPNetworks;
-        _additionalUnsafeIPAddresses = options.AdditionalUnsafeIPAddresses;
-        _safeIPNetworks = options.SafeIPNetworks;
-        _safeIPAddresses = options.SafeIPAddresses;
-        _allowedHostnames = options.AllowedHostnames;
-        _allowedSchemes = snapshotAllowedSchemes;
+        // Snapshot all the collection based settings to ignore any mutation after the handler has been constructed.
+        _additionalUnsafeIPNetworks = options.AdditionalUnsafeIPNetworks != null ? [.. options.AdditionalUnsafeIPNetworks] : null;
+        _additionalUnsafeIPAddresses = options.AdditionalUnsafeIPAddresses != null ? [.. options.AdditionalUnsafeIPAddresses] : null;
+        _safeIPNetworks = options.SafeIPNetworks != null ? [.. options.SafeIPNetworks] : null;
+        _safeIPAddresses = options.SafeIPAddresses != null ? [.. options.SafeIPAddresses] : null;
+        _allowedHostnames = options.AllowedHostnames != null ? [.. options.AllowedHostnames] : null;
+        _allowedSchemes = options.AllowedSchemes is null ? null : [.. options.AllowedSchemes];
         _allowLoopback = options.AllowLoopback;
         _failMixedResults = options.FailMixedResults;
         _hostEntryResolver = hostEntryResolver ?? Defaults.GetHostEntry;

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -307,6 +307,13 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
             throw;
         }
 
+        // Pin the request URI to the validated reference so that any mutation to request.RequestUri
+        // between this validation and the inner handler dispatching to the proxy does not change the
+        // destination behind the SSRF check. The proxy receives request.RequestUri verbatim from the
+        // SocketsHttpHandler, which reads it lazily; without this assignment a sibling handler could
+        // swap RequestUri for a different value after validation completes.
+        request.RequestUri = requestedUri;
+
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
@@ -354,6 +361,9 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
             _metrics.IncrementBlockedRequests();
             throw;
         }
+
+        // Pin the request URI to the validated reference. See the comment in SendAsync for rationale.
+        request.RequestUri = requestedUri;
 
         return base.Send(request, cancellationToken);
     }

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.Metrics;
-using System.Drawing;
 using System.Net;
 using System.Net.Security;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Win32;
 
 namespace idunno.Security;
 

--- a/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
+++ b/src/idunno.Security.Ssrf/ProxiedSsrfDelegatingHandler.cs
@@ -42,7 +42,7 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
     /// <param name="additionalUnsafeIPNetworks">An optional collection of additional <see cref="IPNetwork"/> ranges to consider unsafe. This can be used to block additional IP ranges beyond the built-in defaults, such as internal application IP ranges or other known unsafe addresses.</param>
     /// <param name="additionalUnsafeIPAddresses">An optional collection of additional <see cref="IPAddress"/> addresses to consider unsafe. This can be used to block additional IP addresses beyond the built-in defaults, such as internal application IP addresses or other known unsafe addresses.</param>
     /// <param name="allowedHostnames">
-    ///     An optional collection of hostnames that will bypass all SSRF checks.
+    ///     An optional collection of hostnames that bypass hostname and IP/DNS-based SSRF validation after URI-level safety checks have passed.
     ///     Wild cards are supported only at the start of the hostname, and must be followed by a dot
     ///     (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </param>
@@ -62,13 +62,13 @@ public class ProxiedSsrfDelegatingHandler : DelegatingHandler
     /// <remarks>
     /// <para>
     ///   Specifying a hostname or wildcard pattern in <paramref name="allowedHostnames"/> will allow that
-    ///    hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
-    ///    Take care when using this setting to only allow specific trusted hostnames or patterns.
-    ///    Only specify a hostname under your control.
-    ///    Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
-    ///    *.herokuapp.com, or *.vercel.app would allow an attacker who can 
-    ///    register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
-    ///    obtain a full SSRF.
+    ///   hostname to bypass the checks for unsafe IP addresses.
+    ///   Take care when using this setting to only allow specific trusted hostnames or patterns.
+    ///   Only specify a hostname under your control.
+    ///   Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+    ///   *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+    ///   register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+    ///   obtain a full SSRF.
     /// </para>
     /// <para>
     ///   Careless use of <paramref name="safeIPNetworks"/> and <paramref name="safeIPAddresses"/> can lead to security vulnerabilities by allowing potentially unsafe IP addresses or networks

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -361,6 +361,13 @@ public static class Ssrf
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="uri"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// <para>
+    ///   Warning! This method is for non-HTTP scenarios, input validation or pre-flight only. For HTTP or WebSocket
+    ///   requests <see cref="SsrfSocketsHttpHandlerFactory"/>  or <see cref="ProxiedSsrfDelegatingHandler"/>
+    ///   should be preferred to avoid DNS - rebinding Time of Check, Time of Use (TOCTOU) issues,
+    ///   and to provide more comprehensive protection by integrating SSRF checks directly into the
+    ///   HTTP request pipeline.
+    /// </para>
+    /// <para>
     ///   Careless use of <paramref name="safeIPNetworks"/> and <paramref name="safeIPAddresses"/> can lead to security vulnerabilities by allowing potentially unsafe IP addresses or networks
     ///   to be considered safe. Use with caution and constrain the values specified to the smallest network range or individual IP addresses needed.
     ///   Safe entries take precedence over both built-in and additional unsafe entries, so if an IP address matches both a safe and unsafe address, or is within a safe network,

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -496,15 +496,142 @@ public static class Ssrf
             return false;
         }
 
+        // AllowedHostnames is a DNS hostname allow-list. IP-literal Hosts must be controlled via
+        // SafeIPAddresses / SafeIPNetworks, which compose with the unsafe-range checks in the
+        // correct order. Skipping IP-literal hosts here also closes the wildcard-matches-IP
+        // bypass (e.g. an entry like "*.169.254" textually matching "169.254.169.254").
+        if (uri.HostNameType is not UriHostNameType.Dns)
+        {
+            return false;
+        }
+
         foreach (string safeHostName in allowedHostnames)
         {
-            bool isWildcard = safeHostName.StartsWith("*.", StringComparison.OrdinalIgnoreCase) && safeHostName != "*.";
+            // Layer 1 (defense-in-depth): silently skip entries that are not DNS-shaped patterns.
+            // Public entry points reject these at construction time via ValidateAllowedHostnamePatterns,
+            // but runtime mutation of the underlying collection could re-introduce them.
+            if (!TryValidateAllowedHostnamePattern(safeHostName, out _))
+            {
+                continue;
+            }
+
+            bool isWildcard = safeHostName.StartsWith("*.", StringComparison.Ordinal);
 
             if (!isWildcard && string.Equals(uri.Host, safeHostName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
-            else if (isWildcard && uri.Host.EndsWith(safeHostName[1..], StringComparison.OrdinalIgnoreCase))
+            else if (isWildcard && uri.Host.AsSpan().EndsWith(safeHostName.AsSpan(1), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Validates every entry in <paramref name="allowedHostnames"/>, throwing <see cref="ArgumentException"/>
+    /// for any entry that is not a DNS hostname pattern.
+    /// </summary>
+    /// <param name="allowedHostnames">The collection of patterns to validate. May be <see langword="null"/>.</param>
+    /// <param name="paramName">The parameter name to report on the thrown <see cref="ArgumentException"/>.</param>
+    /// <exception cref="ArgumentException">Thrown when an entry in <paramref name="allowedHostnames"/> is not a valid DNS hostname pattern.</exception>
+    internal static void ValidateAllowedHostnamePatterns(
+        ICollection<string>? allowedHostnames,
+        string paramName)
+    {
+        if (allowedHostnames is null)
+        {
+            return;
+        }
+
+        foreach (string entry in allowedHostnames)
+        {
+            if (!TryValidateAllowedHostnamePattern(entry, out string? errorMessage))
+            {
+                throw new ArgumentException(errorMessage, paramName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="entry"/> is a valid DNS hostname allow-list pattern.
+    /// </summary>
+    /// <remarks>
+    /// <para>A valid pattern is either a DNS hostname (e.g. <c>example.com</c>) or a leading-wildcard
+    /// suffix pattern (e.g. <c>*.example.com</c>). Patterns whose body parses as an IP address, contains
+    /// characters that cannot appear in a DNS host (<c>:</c>, <c>/</c>, <c>@</c>, <c>?</c>, <c>#</c>,
+    /// embedded <c>*</c>, or whitespace), or whose right-most label is purely numeric, are rejected.
+    /// The numeric-label rule prevents wildcard suffixes such as <c>*.0.0.1</c> or <c>*.169.254</c>
+    /// from being matched against IPv4 literals via <see cref="string.EndsWith(string, StringComparison)"/>.</para>
+    /// </remarks>
+    [SuppressMessage("Minor Code Smell", "S3267:Loops should be simplified with \"LINQ\" expressions", Justification = "Avoid allocations.")]
+    internal static bool TryValidateAllowedHostnamePattern(
+        string? entry,
+        [NotNullWhen(false)] out string? errorMessage)
+    {
+        if (string.IsNullOrEmpty(entry))
+        {
+            errorMessage = "AllowedHostnames entries must be non-null and non-empty.";
+            return false;
+        }
+
+        if (entry is "*" or "*.")
+        {
+            errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
+            return false;
+        }
+
+        bool isWildcard = entry.StartsWith("*.", StringComparison.Ordinal);
+        ReadOnlySpan<char> body = isWildcard ? entry.AsSpan(2) : entry.AsSpan();
+
+        if (body.IsEmpty)
+        {
+            errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
+            return false;
+        }
+
+        foreach (char c in body)
+        {
+            if (c is '*' or '/' or ':' or '@' or '?' or '#' or ' ')
+            {
+                errorMessage = $"AllowedHostnames entry '{entry}' contains the unsupported character '{c}'. " +
+                               "Wildcards are only supported as a leading '*.'.";
+                return false;
+            }
+        }
+
+        if (IPAddress.TryParse(body, out _))
+        {
+            errorMessage = $"AllowedHostnames entry '{entry}' is an IP address. " +
+                           "Use SafeIPAddresses or SafeIPNetworks to allow specific IP addresses or ranges.";
+            return false;
+        }
+
+        if (!HasNonNumericRightmostLabel(body))
+        {
+            errorMessage = $"AllowedHostnames entry '{entry}' is not a DNS hostname pattern. " +
+                           "The right-most label must contain at least one non-digit character.";
+            return false;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    private static bool HasNonNumericRightmostLabel(ReadOnlySpan<char> suffix)
+    {
+        int lastDot = suffix.LastIndexOf('.');
+        ReadOnlySpan<char> rightmost = lastDot < 0 ? suffix : suffix[(lastDot + 1)..];
+        if (rightmost.IsEmpty)
+        {
+            return false;
+        }
+
+        foreach (char c in rightmost)
+        {
+            if (c is < '0' or > '9')
             {
                 return true;
             }

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -592,6 +592,13 @@ public static class Ssrf
             return false;
         }
 
+        if (IPAddress.TryParse(body, out _))
+        {
+            errorMessage = $"AllowedHostnames entry '{entry}' is an IP address. " +
+                           "Use SafeIPAddresses or SafeIPNetworks to allow specific IP addresses or ranges.";
+            return false;
+        }
+
         int lastDotIndex = body.LastIndexOf('.');
         ReadOnlySpan<char> rightmostLabel = lastDotIndex >= 0 ? body[(lastDotIndex + 1)..] : body;
 
@@ -634,13 +641,6 @@ public static class Ssrf
 
             currentLabelLength++;
             previousChar = c;
-        }
-
-        if (IPAddress.TryParse(body, out _))
-        {
-            errorMessage = $"AllowedHostnames entry '{entry}' is an IP address. " +
-                           "Use SafeIPAddresses or SafeIPNetworks to allow specific IP addresses or ranges.";
-            return false;
         }
 
         if (!HasNonNumericRightmostLabel(body))

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -634,13 +634,6 @@ public static class Ssrf
 
             currentLabelLength++;
             previousChar = c;
-
-
-            if (currentLabelLength == 0 || previousChar == '-')
-            {
-                errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
-                return false;
-            }
         }
 
         if (IPAddress.TryParse(body, out _))

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -362,7 +362,7 @@ public static class Ssrf
     /// <remarks>
     /// <para>
     ///   Warning! This method is for non-HTTP scenarios, input validation or pre-flight only. For HTTP or WebSocket
-    ///   requests <see cref="SsrfSocketsHttpHandlerFactory"/>  or <see cref="ProxiedSsrfDelegatingHandler"/>
+    ///   requests <see cref="SsrfSocketsHttpHandlerFactory"/> or <see cref="ProxiedSsrfDelegatingHandler"/>
     ///   should be preferred to avoid DNS - rebinding Time of Check, Time of Use (TOCTOU) issues,
     ///   and to provide more comprehensive protection by integrating SSRF checks directly into the
     ///   HTTP request pipeline.
@@ -601,23 +601,44 @@ public static class Ssrf
             return false;
         }
 
-        string[] segments = body.ToString().Split('.');
-        foreach (string segment in segments)
+        int currentLabelLength = 0;
+        char previousChar = '\0';
+
+        foreach (char c in body)
         {
-            if (string.IsNullOrWhiteSpace(segment) || segment.StartsWith('.') || segment.EndsWith('.') || segment.StartsWith('-') || segment.EndsWith('-') ||
-                segment.Contains("..", StringComparison.InvariantCultureIgnoreCase))
+            if (c == '.')
+            {
+                if (currentLabelLength == 0 || previousChar == '-')
+                {
+                    errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
+                    return false;
+                }
+
+                currentLabelLength = 0;
+                previousChar = c;
+                continue;
+            }
+
+            if (!char.IsLetterOrDigit(c) && c != '-')
+            {
+                errorMessage = $"AllowedHostnames entry '{entry}' contains the unsupported character '{c}'. " +
+                               "Wildcards are only supported as a leading '*.'.";
+                return false;
+            }
+
+            if (currentLabelLength == 0 && c == '-')
             {
                 errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
                 return false;
             }
-        }
 
-        foreach (char c in body)
-        {
-            if (!char.IsLetterOrDigit(c) && c != '-' && c != '.')
+            currentLabelLength++;
+            previousChar = c;
+
+
+            if (currentLabelLength == 0 || previousChar == '-')
             {
-                errorMessage = $"AllowedHostnames entry '{entry}' contains the unsupported character '{c}'. " +
-                               "Wildcards are only supported as a leading '*.'.";
+                errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
                 return false;
             }
         }

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -586,10 +586,30 @@ public static class Ssrf
         bool isWildcard = entry.StartsWith("*.", StringComparison.Ordinal);
         ReadOnlySpan<char> body = isWildcard ? entry.AsSpan(2) : entry.AsSpan();
 
-        if (body.IsEmpty)
+        if (body.IsEmpty || body.StartsWith(".") || body.EndsWith(".") || body.IndexOf("..") >= 0 || body.StartsWith("-") || body.EndsWith("-"))
         {
             errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
             return false;
+        }
+
+        int lastDotIndex = body.LastIndexOf('.');
+        ReadOnlySpan<char> rightmostLabel = lastDotIndex >= 0 ? body[(lastDotIndex + 1)..] : body;
+
+        if (rightmostLabel.IsEmpty)
+        {
+            errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
+            return false;
+        }
+
+        string[] segments = body.ToString().Split('.');
+        foreach (string segment in segments)
+        {
+            if (string.IsNullOrWhiteSpace(segment) || segment.StartsWith('.') || segment.EndsWith('.') || segment.StartsWith('-') || segment.EndsWith('-') ||
+                segment.Contains("..", StringComparison.InvariantCultureIgnoreCase))
+            {
+                errorMessage = $"'{entry}' is not a valid AllowedHostnames pattern.";
+                return false;
+            }
         }
 
         foreach (char c in body)

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -594,7 +594,7 @@ public static class Ssrf
 
         foreach (char c in body)
         {
-            if (c is '*' or '/' or ':' or '@' or '?' or '#' or ' ')
+            if (!char.IsLetterOrDigit(c) && c != '-' && c != '.')
             {
                 errorMessage = $"AllowedHostnames entry '{entry}' contains the unsupported character '{c}'. " +
                                "Wildcards are only supported as a leading '*.'.";

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -363,7 +363,7 @@ public static class Ssrf
     /// <para>
     ///   Warning! This method is for non-HTTP scenarios, input validation or pre-flight only. For HTTP or WebSocket
     ///   requests <see cref="SsrfSocketsHttpHandlerFactory"/> or <see cref="ProxiedSsrfDelegatingHandler"/>
-    ///   should be preferred to avoid DNS - rebinding Time of Check, Time of Use (TOCTOU) issues,
+    ///   should be preferred to avoid DNS rebinding Time of Check, Time of Use (TOCTOU) issues,
     ///   and to provide more comprehensive protection by integrating SSRF checks directly into the
     ///   HTTP request pipeline.
     /// </para>

--- a/src/idunno.Security.Ssrf/SsrfOptions.cs
+++ b/src/idunno.Security.Ssrf/SsrfOptions.cs
@@ -68,7 +68,7 @@ public record SsrfOptions
 
     /// <summary>
     /// Gets or sets a collection of hostnames that bypass hostname and IP/DNS-based SSRF validation after URI-level safety checks have passed.
-    /// This can be used to allow specific trusted host names.
+    /// This can be used to allow specific trusted hosts.
     /// Wild cards are supported only at the start of the hostname, and must be followed by a dot
     /// (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </summary>

--- a/src/idunno.Security.Ssrf/SsrfOptions.cs
+++ b/src/idunno.Security.Ssrf/SsrfOptions.cs
@@ -68,7 +68,7 @@ public record SsrfOptions
 
     /// <summary>
     /// Gets or sets a collection of hostnames that bypass hostname and IP/DNS-based SSRF validation after URI-level safety checks have passed.
-    /// This can be used to allow specific trusted hosts names.
+    /// This can be used to allow specific trusted host names.
     /// Wild cards are supported only at the start of the hostname, and must be followed by a dot
     /// (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </summary>

--- a/src/idunno.Security.Ssrf/SsrfOptions.cs
+++ b/src/idunno.Security.Ssrf/SsrfOptions.cs
@@ -67,7 +67,7 @@ public record SsrfOptions
     public bool AllowLoopback { get; set; }
 
     /// <summary>
-    /// Gets or a collection of hostnames that will bypass all SSRF checks.
+    /// Gets or sets a collection of hostnames that bypass hostname and IP/DNS-based SSRF validation after URI-level safety checks have passed.
     /// This can be used to allow specific trusted hosts names.
     /// Wild cards are supported only at the start of the hostname, and must be followed by a dot
     /// (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
@@ -75,7 +75,7 @@ public record SsrfOptions
     /// <remarks>
     /// <para>
     ///   Specifying a hostname or wildcard pattern in <see cref="AllowedHostnames"/> will allow that
-    ///   hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+    ///   hostname to bypass the checks for unsafe IP addresses.
     ///   Take care when using this setting to only allow specific trusted hostnames or patterns.
     ///   Only specify a hostname under your control.
     ///   Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,

--- a/src/idunno.Security.Ssrf/SsrfOptions.cs
+++ b/src/idunno.Security.Ssrf/SsrfOptions.cs
@@ -67,14 +67,22 @@ public record SsrfOptions
     public bool AllowLoopback { get; set; }
 
     /// <summary>
-    /// Gets or a collection of hostnames that are allowed to bypass SSRF IP address protections.
+    /// Gets or a collection of hostnames that will bypass all SSRF checks.
     /// This can be used to allow specific trusted hosts names.
     /// Wild cards are supported only at the start of the hostname, and must be followed by a dot
     /// (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </summary>
     /// <remarks>
-    /// <para>This list does not affect the evaluation of the URI scheme, loopback status, or other built-in SSRF protections.</para>
-    /// <para>The list is considered trusted data. No validation is performed on it. Do not use user-controlled input to build the list.</para>
+    /// <para>
+    ///   Specifying a hostname or wildcard pattern in <see cref="AllowedHostnames"/> will allow that
+    ///   hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+    ///   Take care when using this setting to only allow specific trusted hostnames or patterns.
+    ///   Only specify a hostname under your control.
+    ///   Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+    ///   *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+    ///   register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+    ///   obtain a full SSRF.
+    /// </para>
     /// </remarks>
     public ICollection<string>? AllowedHostnames { get; init; } = [];
 

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -200,7 +200,7 @@ public sealed class SsrfSocketsHttpHandlerFactory
         SsrfMetrics metrics = new(meterFactory);
 
         // Snapshot all the collection based settings to ignore any mutation after the handler has been constructed.
-        ICollection<IPNetwork>? snapshottedAdditionalUnsafeIPNetworks = additionalUnsafeIPNetworks != null? [.. additionalUnsafeIPNetworks] : null;
+        ICollection<IPNetwork>? snapshottedAdditionalUnsafeIPNetworks = additionalUnsafeIPNetworks != null ? [.. additionalUnsafeIPNetworks] : null;
         ICollection<IPAddress>? snapshottedAdditionalUnsafeIPAddresses = additionalUnsafeIPAddresses != null ? [.. additionalUnsafeIPAddresses] : null;
         ICollection<string>? snapshottedAllowedHostnames = allowedHostnames != null ? [.. allowedHostnames] : null;
         ICollection<IPNetwork>? snapshottedSafeIPNetworks = safeIPNetworks != null ? [.. safeIPNetworks] : null;

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -231,7 +231,7 @@ public sealed class SsrfSocketsHttpHandlerFactory
                 IPAddress[] resolvedIPAddresses;
 
                 bool requestIsToProxy = proxy?.Address is Uri proxyAddress &&
-                    context.DnsEndPoint.Host.Equals(proxyAddress.IdnHost, StringComparison.OrdinalIgnoreCase) &&
+                    DnsEndpointHostEqualsUriHost(context.DnsEndPoint.Host, proxyAddress.IdnHost) &&
                     context.DnsEndPoint.Port == proxyAddress.Port;
 
                 if (requestIsToProxy)
@@ -257,6 +257,21 @@ public sealed class SsrfSocketsHttpHandlerFactory
                         Log.UnsafeUri(logger, requestedUri);
                         metrics.IncrementBlockedRequests();
                         throw new SsrfException(requestedUri, $"Connection blocked as the uri is considered unsafe.");
+                    }
+
+                    // Defense-in-depth: SocketsHttpHandler is expected to invoke this callback with a DnsEndPoint
+                    // whose Host and Port match the request URI when no proxy is in use. If those ever diverge
+                    // (e.g. due to a future runtime change, an injected handler that rewrites the connect target,
+                    // or an unexpected codepath) the SSRF validation we are about to perform on requestedUri would
+                    // not describe what we are actually about to connect to. Fail closed if the invariant breaks.
+                    if (!DnsEndpointHostEqualsUriHost(context.DnsEndPoint.Host, requestedUri.IdnHost) ||
+                        context.DnsEndPoint.Port != requestedUri.Port)
+                    {
+                        Log.UnsafeUri(logger, requestedUri);
+                        metrics.IncrementBlockedRequests();
+                        throw new SsrfException(
+                            requestedUri,
+                            $"Connection blocked as the connect endpoint '{context.DnsEndPoint.Host}:{context.DnsEndPoint.Port}' does not match the request URI authority.");
                     }
 
                     try
@@ -360,6 +375,32 @@ public sealed class SsrfSocketsHttpHandlerFactory
             handler.UseProxy = true;
         }
         return handler;
+    }
+
+    /// <summary>
+    /// Compares <paramref name="endpointHost"/> (as supplied by <see cref="SocketsHttpHandler"/> via
+    /// <see cref="System.Net.DnsEndPoint.Host"/>) to <paramref name="uriIdnHost"/> (as supplied by
+    /// <see cref="Uri.IdnHost"/>), normalizing the bracketed form that <see cref="SocketsHttpHandler"/> uses
+    /// for IPv6 literals (e.g. <c>[::1]</c>) before comparing.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="SocketsHttpHandler"/> emits IPv6 literals in <see cref="System.Net.DnsEndPoint.Host"/>
+    /// in the bracketed form (<c>[::1]</c>), but <see cref="Uri.IdnHost"/> strips the brackets (<c>::1</c>).
+    /// A naïve <see cref="string.Equals(string, StringComparison)"/> would therefore mis-classify IPv6 proxies
+    /// or IPv6 request URIs. For IDN names and IPv4 literals both sides agree without normalization.</para>
+    /// </remarks>
+    internal static bool DnsEndpointHostEqualsUriHost(string endpointHost, string uriIdnHost)
+    {
+        ArgumentNullException.ThrowIfNull(endpointHost);
+        ArgumentNullException.ThrowIfNull(uriIdnHost);
+
+        ReadOnlySpan<char> endpoint = endpointHost.AsSpan();
+        if (endpoint.Length >= 2 && endpoint[0] == '[' && endpoint[^1] == ']')
+        {
+            endpoint = endpoint[1..^1];
+        }
+
+        return endpoint.Equals(uriIdnHost.AsSpan(), StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -32,7 +32,7 @@ public sealed class SsrfSocketsHttpHandlerFactory
     /// <param name="additionalUnsafeIPNetworks">An optional collection of additional <see cref="IPNetwork"/> ranges to consider unsafe. This can be used to block additional IP ranges beyond the built-in defaults, such as internal application IP ranges or other known unsafe addresses.</param>
     /// <param name="additionalUnsafeIPAddresses">An optional collection of additional <see cref="IPAddress"/> addresses to consider unsafe. This can be used to block additional IP addresses beyond the built-in defaults, such as internal application IP addresses or other known unsafe addresses.</param>
     /// <param name="allowedHostnames">
-    ///     An optional collection of hostnames that will bypass all SSRF checks.
+    ///     An optional collection of hostnames that bypass hostname and IP/DNS-based SSRF validation after URI-level safety checks have passed.
     ///     Wild cards are supported only at the start of the hostname, and must be followed by a dot
     ///     (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </param>
@@ -51,13 +51,13 @@ public sealed class SsrfSocketsHttpHandlerFactory
     /// <remarks>
     /// <para>
     ///   Specifying a hostname or wildcard pattern in <paramref name="allowedHostnames"/> will allow that
-    ///    hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
-    ///    Take care when using this setting to only allow specific trusted hostnames or patterns.
-    ///    Only specify a hostname under your control.
-    ///    Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
-    ///    *.herokuapp.com, or *.vercel.app would allow an attacker who can 
-    ///    register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
-    ///    obtain a full SSRF.
+    ///   hostname to bypass the checks for unsafe IP addresses.
+    ///   Take care when using this setting to only allow specific trusted hostnames or patterns.
+    ///   Only specify a hostname under your control.
+    ///   Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+    ///   *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+    ///   register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+    ///   obtain a full SSRF.
     /// </para>
     /// <para>
     ///   Careless use of <paramref name="safeIPNetworks"/> and <paramref name="safeIPAddresses"/> can lead to security vulnerabilities by allowing potentially unsafe IP addresses or networks
@@ -262,7 +262,7 @@ public sealed class SsrfSocketsHttpHandlerFactory
                     // Defense-in-depth: SocketsHttpHandler is expected to invoke this callback with a DnsEndPoint
                     // whose Host and Port match the request URI when no proxy is in use. If those ever diverge
                     // (e.g. due to a future runtime change, an injected handler that rewrites the connect target,
-                    // or an unexpected codepath) the SSRF validation we are about to perform on requestedUri would
+                    // or an unexpected code path) the SSRF validation we are about to perform on requestedUri would
                     // not describe what we are actually about to connect to. Fail closed if the invariant breaks.
                     if (!DnsEndpointHostEqualsUriHost(context.DnsEndPoint.Host, requestedUri.IdnHost) ||
                         context.DnsEndPoint.Port != requestedUri.Port)

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -32,8 +32,7 @@ public sealed class SsrfSocketsHttpHandlerFactory
     /// <param name="additionalUnsafeIPNetworks">An optional collection of additional <see cref="IPNetwork"/> ranges to consider unsafe. This can be used to block additional IP ranges beyond the built-in defaults, such as internal application IP ranges or other known unsafe addresses.</param>
     /// <param name="additionalUnsafeIPAddresses">An optional collection of additional <see cref="IPAddress"/> addresses to consider unsafe. This can be used to block additional IP addresses beyond the built-in defaults, such as internal application IP addresses or other known unsafe addresses.</param>
     /// <param name="allowedHostnames">
-    ///     An optional collection of hostnames that are allowed to bypass SSRF IP address protections.
-    ///     This can be used to allow specific trusted hosts names.
+    ///     An optional collection of hostnames that will bypass all SSRF checks.
     ///     Wild cards are supported only at the start of the hostname, and must be followed by a dot
     ///     (e.g. "*.example.com" would allow "api.example.com", "test.api.example.com", but not "example.com").
     /// </param>
@@ -51,10 +50,22 @@ public sealed class SsrfSocketsHttpHandlerFactory
     /// <returns>An new instance of a <see cref="SocketsHttpHandler"/> with SSRF protections.</returns>
     /// <remarks>
     /// <para>
+    ///   Specifying a hostname or wildcard pattern in <paramref name="allowedHostnames"/> will allow that
+    ///    hostname to bypass all SSRF checks, including checks for unsafe IP addresses.
+    ///    Take care when using this setting to only allow specific trusted hostnames or patterns.
+    ///    Only specify a hostname under your control.
+    ///    Use of wildcards for shared hosting domains such as *.s3.amazonaws.com, *.blob.core.windows.net,
+    ///    *.herokuapp.com, or *.vercel.app would allow an attacker who can 
+    ///    register a subdomain to point it at 127.0.0.1, 169.254.169.254 (cloud metadata), or any RFC1918 address and
+    ///    obtain a full SSRF.
+    /// </para>
+    /// <para>
     ///   Careless use of <paramref name="safeIPNetworks"/> and <paramref name="safeIPAddresses"/> can lead to security vulnerabilities by allowing potentially unsafe IP addresses or networks
     ///   to be considered safe. Use with caution and constrain the values specified to the smallest network range or individual IP addresses needed.
     ///   Safe entries take precedence over both built-in and additional unsafe entries, so if an IP address matches both a safe and unsafe address, or is within a safe network,
     ///   it will be considered safe.
+    ///
+    ///   Add additional entries in normalized IPv4 form for IPv4-embedded IPv6 addresses or networks.
     ///</para>
     /// </remarks>
     public static SocketsHttpHandler Create(
@@ -184,6 +195,12 @@ public sealed class SsrfSocketsHttpHandlerFactory
         ILogger logger = loggerFactory.CreateLogger<SsrfSocketsHttpHandlerFactory>();
         SsrfMetrics metrics = new(meterFactory);
 
+        // Snapshot all the collection based settings to ignore any mutation after the handler has been constructed.
+        ICollection<IPNetwork>? snapshottedAdditionalUnsafeIPNetworks = additionalUnsafeIPNetworks != null? [.. additionalUnsafeIPNetworks] : null;
+        ICollection<IPAddress>? snapshottedAdditionalUnsafeIPAddresses = additionalUnsafeIPAddresses != null ? [.. additionalUnsafeIPAddresses] : null;
+        ICollection<string>? snapshottedAllowedHostnames = allowedHostnames != null ? [.. allowedHostnames] : null;
+        ICollection<IPNetwork>? snapshottedSafeIPNetworks = safeIPNetworks != null ? [.. safeIPNetworks] : null;
+        ICollection<IPAddress>? snapshottedSafeIPAddresses = safeIPAddresses != null ? [.. safeIPAddresses] : null;
         ICollection<string> snapshottedAllowedSchemes = allowedSchemes != null ? [.. allowedSchemes] : Defaults.AllowedSchemes;
 
         SocketsHttpHandler handler = new()
@@ -242,11 +259,11 @@ public sealed class SsrfSocketsHttpHandlerFactory
                     {
                         resolvedIPAddresses = await CommonFunctions.ResolveAndReturnSafeIPAddressesAsync(
                             uri: requestedUri,
-                            additionalUnsafeIPNetworks: additionalUnsafeIPNetworks,
-                            additionalUnsafeIPAddresses: additionalUnsafeIPAddresses,
-                            allowedHostnames: allowedHostnames,
-                            safeIPNetworks: safeIPNetworks,
-                            safeIPAddresses: safeIPAddresses,
+                            additionalUnsafeIPNetworks: snapshottedAdditionalUnsafeIPNetworks,
+                            additionalUnsafeIPAddresses: snapshottedAdditionalUnsafeIPAddresses,
+                            allowedHostnames: snapshottedAllowedHostnames,
+                            safeIPNetworks: snapshottedSafeIPNetworks,
+                            safeIPAddresses: snapshottedSafeIPAddresses,
                             allowLoopback: allowLoopback,
                             failMixedResults: failMixedResults,
                             logger: logger,

--- a/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
+++ b/src/idunno.Security.Ssrf/SsrfSocketsHttpHandlerFactory.cs
@@ -146,6 +146,8 @@ public sealed class SsrfSocketsHttpHandlerFactory
             throw new ArgumentException("SsrfSocketsHttpHandlerFactory cannot accept ProxiedSsrfOptions. Use ProxiedSsrfDelegatingHandler with ProxiedSsrfOptions for configurations that include proxy settings.", nameof(options));
         }
 
+        Ssrf.ValidateAllowedHostnamePatterns(options.AllowedHostnames, nameof(options));
+
         return InternalCreate(
             connectionStrategy: options.ConnectionStrategy,
             additionalUnsafeIPNetworks: options.AdditionalUnsafeIPNetworks,
@@ -189,6 +191,8 @@ public sealed class SsrfSocketsHttpHandlerFactory
         { 
             throw new ArgumentException("The WebProxy instance must have a non-null Address property.", nameof(proxy));
         }
+
+        Ssrf.ValidateAllowedHostnamePatterns(allowedHostnames, nameof(allowedHostnames));
 
         asyncHostEntryResolver ??= Defaults.GetHostEntryAsync;
         loggerFactory ??= NullLoggerFactory.Instance;

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -180,6 +180,13 @@ public class TryValidateAllowedHostname
     [InlineData("example.com:8080")]
     [InlineData("user@example.com")]
     [InlineData("with space.example.com")]
+    [InlineData(".example.com")]
+    [InlineData(".example.com.")]
+    [InlineData("example.com.")]
+    [InlineData("example..com")]
+    [InlineData("-example.com")]
+    [InlineData("example-.com")]
+
     public void ReturnsFalseForInvalidPatterns(string pattern)
     {
         Assert.False(Ssrf.TryValidateAllowedHostnamePattern(pattern, out string? error));

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -90,4 +90,156 @@ public class IsInAllowedHostNames
         var allowedHostNames = new List<string> { "example.com", "test.com" };
         Assert.False(Ssrf.IsInAllowedHostnames(new Uri("https://example.com."), allowedHostNames));
     }
+
+    [Theory]
+    [InlineData("https://127.0.0.1/", "127.0.0.1")]
+    [InlineData("https://10.0.0.1/", "10.0.0.1")]
+    [InlineData("https://169.254.169.254/", "169.254.169.254")]
+    [InlineData("https://[::1]/", "::1")]
+    [InlineData("https://[2001:db8::1]/", "2001:db8::1")]
+    public void ReturnsFalseWhenUriHostIsAnIPLiteralEvenIfPresentInTheList(string uri, string entry)
+    {
+        // AllowedHostnames is a hostname allow-list, not an IP allow-list. IP literals must
+        // be controlled via SafeIPAddresses / SafeIPNetworks.
+        Assert.False(Ssrf.IsInAllowedHostnames(new Uri(uri), [entry]));
+    }
+
+    [Theory]
+    [InlineData("https://169.254.169.254/", "*.169.254")]
+    [InlineData("https://10.0.0.1/", "*.0.0.1")]
+    [InlineData("https://192.168.1.1/", "*.1.1")]
+    [InlineData("https://127.0.0.1/", "*.0.0.1")]
+    public void WildcardWithNumericSuffixDoesNotMatchIPLiteralHost(string uri, string pattern)
+    {
+        // The textual EndsWith match would otherwise allow an attacker-supplied wildcard like "*.169.254"
+        // to bypass the IP unsafe-range check by matching the IP literal as a string.
+        Assert.False(Ssrf.IsInAllowedHostnames(new Uri(uri), [pattern]));
+    }
+
+    [Theory]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("127.0.0.1")]
+    [InlineData("*foo.example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("")]
+    [InlineData("*")]
+    [InlineData("*.")]
+    public void InvalidPatternsAreSkippedSilentlyAtMatchTime(string invalidPattern)
+    {
+        // Defense-in-depth: even if a malformed entry is somehow re-introduced after construction
+        // (e.g. via runtime mutation of the collection), match-time validation refuses to match it.
+        Assert.False(Ssrf.IsInAllowedHostnames(
+            new Uri("https://anything.example.com/"),
+            [invalidPattern]));
+    }
+
+    [Fact]
+    public void ValidPatternsAroundInvalidEntriesStillMatch()
+    {
+        var allowedHostNames = new List<string> { "*.0.0.1", "*.example.com", "127.0.0.1" };
+        Assert.True(Ssrf.IsInAllowedHostnames(new Uri("https://api.example.com/"), allowedHostNames));
+    }
+}
+
+public class TryValidateAllowedHostnamePattern
+{
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("*.example.com")]
+    [InlineData("*.api.example.com")]
+    [InlineData("co.uk")]
+    [InlineData("*.co.uk")]
+    [InlineData("xn--p1ai")]
+    [InlineData("*.xn--p1ai")]
+    [InlineData("localhost")]
+    [InlineData("*.localhost")]
+    [InlineData("api1.example.com")]
+    [InlineData("my-server.example.com")]
+    public void ReturnsTrueForValidDnsPatterns(string pattern)
+    {
+        Assert.True(Ssrf.TryValidateAllowedHostnamePattern(pattern, out string? error));
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("*")]
+    [InlineData("*.")]
+    [InlineData("127.0.0.1")]
+    [InlineData("169.254.169.254")]
+    [InlineData("::1")]
+    [InlineData("2001:db8::")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("*.10")]
+    [InlineData("*.123")]
+    [InlineData("123.456")]
+    [InlineData("*.example.*")]
+    [InlineData("*foo.example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("example.com/admin")]
+    [InlineData("example.com:8080")]
+    [InlineData("user@example.com")]
+    [InlineData("with space.example.com")]
+    public void ReturnsFalseForInvalidPatterns(string pattern)
+    {
+        Assert.False(Ssrf.TryValidateAllowedHostnamePattern(pattern, out string? error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void ReturnsFalseForNullEntry()
+    {
+        Assert.False(Ssrf.TryValidateAllowedHostnamePattern(null, out string? error));
+        Assert.NotNull(error);
+    }
+}
+
+public class ValidateAllowedHostnamePatterns
+{
+    [Fact]
+    public void DoesNotThrowForNullCollection()
+    {
+        Ssrf.ValidateAllowedHostnamePatterns(null, "test");
+    }
+
+    [Fact]
+    public void DoesNotThrowForEmptyCollection()
+    {
+        Ssrf.ValidateAllowedHostnamePatterns([], "test");
+    }
+
+    [Fact]
+    public void DoesNotThrowForCollectionOfValidPatterns()
+    {
+        Ssrf.ValidateAllowedHostnamePatterns(
+            ["example.com", "*.example.com", "co.uk", "*.xn--p1ai"],
+            "test");
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("::1")]
+    [InlineData("")]
+    [InlineData("*")]
+    [InlineData("*.")]
+    [InlineData("user@example.com")]
+    public void ThrowsArgumentExceptionForInvalidEntry(string entry)
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => Ssrf.ValidateAllowedHostnamePatterns([entry], "test"));
+        Assert.Equal("test", ex.ParamName);
+    }
+
+    [Fact]
+    public void ThrowsForInvalidEntryEvenIfOtherEntriesAreValid()
+    {
+        Assert.Throws<ArgumentException>(
+            () => Ssrf.ValidateAllowedHostnamePatterns(
+                ["example.com", "*.0.0.1", "test.com"],
+                "test"));
+    }
 }

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Barry Dorrans. All rights reserved.
 // Licensed under the MIT License.
 
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
-
 namespace idunno.Security.SsrfTests;
 
 public class IsInAllowedHostNames
@@ -142,7 +140,7 @@ public class IsInAllowedHostNames
     }
 }
 
-public class TryValidateAllowedHostnamePattern
+public class TryValidateAllowedHostname
 {
     [Theory]
     [InlineData("example.com")]
@@ -196,7 +194,7 @@ public class TryValidateAllowedHostnamePattern
     }
 }
 
-public class ValidateAllowedHostnamePatterns
+public class ValidateAllowedHostname
 {
     [Fact]
     public void DoesNotThrowForNullCollection()
@@ -214,7 +212,12 @@ public class ValidateAllowedHostnamePatterns
     public void DoesNotThrowForCollectionOfValidPatterns()
     {
         Ssrf.ValidateAllowedHostnamePatterns(
-            ["example.com", "*.example.com", "co.uk", "*.xn--p1ai"],
+            [
+                "example.com",
+                "*.example.com",
+                "co.uk",
+                "*.xn--p1ai"
+            ],
             "test");
     }
 
@@ -227,6 +230,10 @@ public class ValidateAllowedHostnamePatterns
     [InlineData("*")]
     [InlineData("*.")]
     [InlineData("user@example.com")]
+    [InlineData("!nvalid.com")]
+    [InlineData("test.*example.com")]
+    [InlineData("*.test.*example.com")]
+    [InlineData("_test.example.com")]
     public void ThrowsArgumentExceptionForInvalidEntry(string entry)
     {
         ArgumentException ex = Assert.Throws<ArgumentException>(
@@ -239,7 +246,11 @@ public class ValidateAllowedHostnamePatterns
     {
         Assert.Throws<ArgumentException>(
             () => Ssrf.ValidateAllowedHostnamePatterns(
-                ["example.com", "*.0.0.1", "test.com"],
+                [
+                    "example.com",
+                    "*.0.0.1",
+                    "test.com"
+                ],
                 "test"));
     }
 }

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Barry Dorrans. All rights reserved.
 // Licensed under the MIT License.
 
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
+
 namespace idunno.Security.SsrfTests;
 
 public class IsInAllowedHostNames
@@ -77,5 +79,15 @@ public class IsInAllowedHostNames
         Assert.True(Ssrf.IsInAllowedHostnames(new Uri("https://example.com"), allowedHostNames));
         Assert.False(Ssrf.IsInAllowedHostnames(new Uri("https://www.example.com"), allowedHostNames));
         Assert.True(Ssrf.IsInAllowedHostnames(new Uri("https://dev.www.example.com"), allowedHostNames));
+    }
+
+    [Fact]
+    public void ReturnsFalseWhenHostHasATrailingDotAndNonTrailingHostIsInAllowedHostNames()
+    {
+        // .NET's Uri.Host historically can preserve a trailing dot (example.com.), in which case attacker.example.com. would
+        // NOT match *.example.com.This is fail - closed(good), this test locks the behavior in.
+
+        var allowedHostNames = new List<string> { "example.com", "test.com" };
+        Assert.False(Ssrf.IsInAllowedHostnames(new Uri("https://example.com."), allowedHostNames));
     }
 }

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -83,7 +83,7 @@ public class IsInAllowedHostNames
     public void ReturnsFalseWhenHostHasATrailingDotAndNonTrailingHostIsInAllowedHostNames()
     {
         // .NET's Uri.Host historically can preserve a trailing dot (example.com.), in which case attacker.example.com. would
-        // NOT match *.example.com. This is fail - closed(good), this test locks the behavior in.
+        // NOT match *.example.com. This test locks the behavior in.
 
         var allowedHostNames = new List<string> { "example.com", "test.com" };
         Assert.False(Ssrf.IsInAllowedHostnames(new Uri("https://example.com."), allowedHostNames));
@@ -186,6 +186,7 @@ public class TryValidateAllowedHostname
     [InlineData("example..com")]
     [InlineData("-example.com")]
     [InlineData("example-.com")]
+
 
     public void ReturnsFalseForInvalidPatterns(string pattern)
     {

--- a/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
+++ b/test/idunno.Security.SsrfTests/IsInAllowedHostNames.cs
@@ -83,7 +83,7 @@ public class IsInAllowedHostNames
     public void ReturnsFalseWhenHostHasATrailingDotAndNonTrailingHostIsInAllowedHostNames()
     {
         // .NET's Uri.Host historically can preserve a trailing dot (example.com.), in which case attacker.example.com. would
-        // NOT match *.example.com.This is fail - closed(good), this test locks the behavior in.
+        // NOT match *.example.com. This is fail - closed(good), this test locks the behavior in.
 
         var allowedHostNames = new List<string> { "example.com", "test.com" };
         Assert.False(Ssrf.IsInAllowedHostnames(new Uri("https://example.com."), allowedHostNames));

--- a/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
+++ b/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
@@ -1187,4 +1187,50 @@ public class ProxiedSsrfDelegatingHandler
             }
         }
     }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("169.254.169.254")]
+    [InlineData("::1")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("")]
+    [InlineData("*")]
+    [InlineData("*.")]
+    [InlineData("user@example.com")]
+    public void ConstructorThrowsArgumentExceptionForInvalidAllowedHostnameWithExplicitParameters(string entry)
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(() =>
+            new Security.ProxiedSsrfDelegatingHandler(
+                proxy: new WebProxy(new Uri("http://127.0.0.1:9999")),
+                allowedHostnames: [entry]));
+        Assert.Equal("allowedHostnames", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("")]
+    public void ConstructorThrowsArgumentExceptionForInvalidAllowedHostnameInOptions(string entry)
+    {
+        var options = new ProxiedSsrfOptions
+        {
+            Proxy = new WebProxy(new Uri("http://127.0.0.1:9999")),
+            AllowedHostnames = [entry],
+        };
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => new Security.ProxiedSsrfDelegatingHandler(options));
+        Assert.Equal("options", ex.ParamName);
+    }
+
+    [Fact]
+    public void ConstructorDoesNotThrowForValidAllowedHostnames()
+    {
+        using var handler = new Security.ProxiedSsrfDelegatingHandler(
+            proxy: new WebProxy(new Uri("http://127.0.0.1:9999")),
+            allowedHostnames: ["example.com", "*.example.com", "*.xn--p1ai", "co.uk"]);
+        Assert.NotNull(handler);
+    }
 }

--- a/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
+++ b/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
@@ -1344,4 +1344,55 @@ public class ProxiedSsrfDelegatingHandler
             };
         }
     }
+
+    [Fact]
+    public async Task ProxyDetectionRecognizesIPv6LiteralProxy()
+    {
+        // The DnsEndPoint that SocketsHttpHandler hands to the connect callback uses the bracketed form
+        // for IPv6 literals (e.g. "[::1]"), while Uri.IdnHost strips them ("::1"). A naive ordinal compare
+        // would mis-classify an IPv6 proxy as a non-proxy connection target. With proxy detection working,
+        // the connect callback should attempt the proxy at [::1]:9999 (no listener -> transport failure),
+        // and crucially should NOT throw SsrfException (which would indicate either the request URI was
+        // re-validated as a connect target, or the defense-in-depth host/port mismatch check fired).
+
+        static IPHostEntry hostEntryResolver(string host)
+            => new() { AddressList = [IPAddress.Parse("93.184.216.34")] };
+
+        static Task<IPHostEntry> asyncHostEntryResolver(string host, CancellationToken cancellationToken)
+            => Task.FromResult(hostEntryResolver(host));
+
+        using var handler = new Security.ProxiedSsrfDelegatingHandler(
+            proxy: new WebProxy(new Uri("http://[::1]:9999")),
+            connectionStrategy: ConnectionStrategy.None,
+            additionalUnsafeIPNetworks: null,
+            additionalUnsafeIPAddresses: null,
+            allowedHostnames: null,
+            safeIPNetworks: null,
+            safeIPAddresses: null,
+            connectTimeout: TimeSpan.FromSeconds(1),
+            allowedSchemes: ["https"],
+            allowLoopback: false,
+            failMixedResults: false,
+            allowAutoRedirect: false,
+            automaticDecompression: null,
+            sslOptions: null,
+            hostEntryResolver: hostEntryResolver,
+            asyncHostEntryResolver: asyncHostEntryResolver,
+            loggerFactory: null,
+            meterFactory: null);
+
+        using var client = new HttpClient(handler);
+
+        Exception? ex = await Record.ExceptionAsync(
+            () => client.GetAsync("https://example.com/", TestContext.Current.CancellationToken));
+
+        Assert.NotNull(ex);
+        Assert.IsNotType<SsrfException>(ex);
+        Exception? innermost = ex;
+        while (innermost.InnerException is not null)
+        {
+            innermost = innermost.InnerException;
+            Assert.IsNotType<SsrfException>(innermost);
+        }
+    }
 }

--- a/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
+++ b/test/idunno.Security.SsrfTests/ProxiedSsrfDelegatingHandler.cs
@@ -1233,4 +1233,115 @@ public class ProxiedSsrfDelegatingHandler
             allowedHostnames: ["example.com", "*.example.com", "*.xn--p1ai", "co.uk"]);
         Assert.NotNull(handler);
     }
+
+    [Fact]
+    public async Task SendAsyncPinsValidatedRequestUriOnRequestBeforeDispatchingToInnerHandler()
+    {
+        static IPHostEntry hostEntryResolver(string host)
+            => new() { HostName = host, AddressList = [IPAddress.Parse("93.184.216.34")] };
+
+        static Task<IPHostEntry> asyncHostEntryResolver(string host, CancellationToken cancellationToken)
+            => Task.FromResult(hostEntryResolver(host));
+
+        var capturingInner = new CapturingHandler();
+
+        using var handler = new Security.ProxiedSsrfDelegatingHandler(
+            proxy: new WebProxy(new Uri("http://127.0.0.1:9999")),
+            connectionStrategy: ConnectionStrategy.None,
+            additionalUnsafeIPNetworks: null,
+            additionalUnsafeIPAddresses: null,
+            allowedHostnames: null,
+            safeIPNetworks: null,
+            safeIPAddresses: null,
+            connectTimeout: TimeSpan.FromSeconds(1),
+            allowedSchemes: ["https"],
+            allowLoopback: false,
+            failMixedResults: false,
+            allowAutoRedirect: false,
+            automaticDecompression: null,
+            sslOptions: null,
+            hostEntryResolver: hostEntryResolver,
+            asyncHostEntryResolver: asyncHostEntryResolver,
+            loggerFactory: null,
+            meterFactory: null)
+        {
+            InnerHandler = capturingInner,
+        };
+
+        using var client = new HttpClient(handler);
+        Uri originalUri = new("https://example.com/path");
+        using var request = new HttpRequestMessage(HttpMethod.Get, originalUri);
+
+        using HttpResponseMessage response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Same(originalUri, capturingInner.ObservedRequestUri);
+        Assert.Same(originalUri, request.RequestUri);
+    }
+
+    [Fact]
+    public void SendPinsValidatedRequestUriOnRequestBeforeDispatchingToInnerHandler()
+    {
+        static IPHostEntry hostEntryResolver(string host)
+            => new() { HostName = host, AddressList = [IPAddress.Parse("93.184.216.34")] };
+
+        static Task<IPHostEntry> asyncHostEntryResolver(string host, CancellationToken cancellationToken)
+            => Task.FromResult(hostEntryResolver(host));
+
+        var capturingInner = new CapturingHandler();
+
+        using var handler = new Security.ProxiedSsrfDelegatingHandler(
+            proxy: new WebProxy(new Uri("http://127.0.0.1:9999")),
+            connectionStrategy: ConnectionStrategy.None,
+            additionalUnsafeIPNetworks: null,
+            additionalUnsafeIPAddresses: null,
+            allowedHostnames: null,
+            safeIPNetworks: null,
+            safeIPAddresses: null,
+            connectTimeout: TimeSpan.FromSeconds(1),
+            allowedSchemes: ["https"],
+            allowLoopback: false,
+            failMixedResults: false,
+            allowAutoRedirect: false,
+            automaticDecompression: null,
+            sslOptions: null,
+            hostEntryResolver: hostEntryResolver,
+            asyncHostEntryResolver: asyncHostEntryResolver,
+            loggerFactory: null,
+            meterFactory: null)
+        {
+            InnerHandler = capturingInner,
+        };
+
+        using var client = new HttpClient(handler);
+        Uri originalUri = new("https://example.com/path");
+        using var request = new HttpRequestMessage(HttpMethod.Get, originalUri);
+
+        using HttpResponseMessage response = client.Send(request, TestContext.Current.CancellationToken);
+
+        Assert.Same(originalUri, capturingInner.ObservedRequestUri);
+        Assert.Same(originalUri, request.RequestUri);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public Uri? ObservedRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            ObservedRequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                RequestMessage = request,
+            });
+        }
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            ObservedRequestUri = request.RequestUri;
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                RequestMessage = request,
+            };
+        }
+    }
 }

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -1187,7 +1187,7 @@ public class SsrfSocketsHttpHandlerFactory
     }
 
     [Fact]
-    public void IpLiteralHostIsNotBypassedByAllowedHostnames()
+    public void IpLiteralHostInAllowedHostnamesThrowsArgumentException()
     {
         // With construction-time validation enabled (Layer 2), an IP literal in AllowedHostnames is
         // rejected up-front rather than only at request time. Use SafeIPAddresses / SafeIPNetworks

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -1173,6 +1173,21 @@ public class SsrfSocketsHttpHandlerFactory
         Assert.Equal(AddressFamily.InterNetwork, addresses[3].AddressFamily);
     }
 
+    [Theory]
+    [InlineData("example.com", "example.com", true)]
+    [InlineData("EXAMPLE.com", "example.COM", true)]
+    [InlineData("127.0.0.1", "127.0.0.1", true)]
+    [InlineData("[::1]", "::1", true)]
+    [InlineData("[2001:db8::1]", "2001:db8::1", true)]
+    [InlineData("[::1]", "[::1]", false)]
+    [InlineData("xn--wgv71a.jp", "xn--wgv71a.jp", true)]
+    [InlineData("example.com", "example.org", false)]
+    [InlineData("[::1]", "::2", false)]
+    public void DnsEndpointHostEqualsUriHostStripsBracketsAndCompares(string endpointHost, string uriIdnHost, bool expected)
+    {
+        Assert.Equal(expected, Security.SsrfSocketsHttpHandlerFactory.DnsEndpointHostEqualsUriHost(endpointHost, uriIdnHost));
+    }
+
     [Fact]
     public void IpLiteralHostIsNotBypassedByAllowedHostnames()
     {

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -3,6 +3,8 @@
 
 using System.Net;
 using System.Net.Sockets;
+using Microsoft.Extensions.Primitives;
+using static System.Net.WebRequestMethods;
 
 namespace idunno.Security.SsrfTests;
 
@@ -1169,5 +1171,33 @@ public class SsrfSocketsHttpHandlerFactory
         Assert.Equal(AddressFamily.InterNetworkV6, addresses[1].AddressFamily);
         Assert.Equal(AddressFamily.InterNetwork, addresses[2].AddressFamily);
         Assert.Equal(AddressFamily.InterNetwork, addresses[3].AddressFamily);
+    }
+
+    [Fact]
+    public async Task IpLiteralHostIsNotBypassedByAllowedHostnames()
+    {
+        string uri = "https://10.0.0.1/";
+
+        var options = new SsrfOptions { AllowedHostnames = ["10.0.0.1"] };
+        using var httpClient = new HttpClient(Security.SsrfSocketsHttpHandlerFactory.Create(options));
+
+        HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(async() =>
+            _ = await httpClient.GetAsync(
+                    uri,
+                    cancellationToken: TestContext.Current.CancellationToken));
+
+        Exception? innermostException = ex;
+        while (innermostException.InnerException is not null)
+        {
+            innermostException = innermostException.InnerException;
+
+            if (innermostException is SsrfException)
+            {
+                break;
+            }
+        }
+
+        Assert.IsType<SsrfException>(innermostException);
+        Assert.Equal(uri, ((SsrfException)ex.InnerException!).Uri!.ToString());
     }
 }

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -3,8 +3,6 @@
 
 using System.Net;
 using System.Net.Sockets;
-using Microsoft.Extensions.Primitives;
-using static System.Net.WebRequestMethods;
 
 namespace idunno.Security.SsrfTests;
 

--- a/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
+++ b/test/idunno.Security.SsrfTests/SsrfSocketsHttpHandlerFactory.cs
@@ -1174,30 +1174,53 @@ public class SsrfSocketsHttpHandlerFactory
     }
 
     [Fact]
-    public async Task IpLiteralHostIsNotBypassedByAllowedHostnames()
+    public void IpLiteralHostIsNotBypassedByAllowedHostnames()
     {
-        string uri = "https://10.0.0.1/";
-
+        // With construction-time validation enabled (Layer 2), an IP literal in AllowedHostnames is
+        // rejected up-front rather than only at request time. Use SafeIPAddresses / SafeIPNetworks
+        // for IP-based allow-listing.
         var options = new SsrfOptions { AllowedHostnames = ["10.0.0.1"] };
-        using var httpClient = new HttpClient(Security.SsrfSocketsHttpHandlerFactory.Create(options));
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => Security.SsrfSocketsHttpHandlerFactory.Create(options));
+        Assert.Equal(nameof(options), ex.ParamName);
+    }
 
-        HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(async() =>
-            _ = await httpClient.GetAsync(
-                    uri,
-                    cancellationToken: TestContext.Current.CancellationToken));
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("169.254.169.254")]
+    [InlineData("::1")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("")]
+    [InlineData("*")]
+    [InlineData("*.")]
+    [InlineData("user@example.com")]
+    [InlineData("https://example.com")]
+    public void CreateThrowsArgumentExceptionForInvalidAllowedHostnameWithExplicitParameters(string entry)
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => Security.SsrfSocketsHttpHandlerFactory.Create(allowedHostnames: [entry]));
+        Assert.Equal("allowedHostnames", ex.ParamName);
+    }
 
-        Exception? innermostException = ex;
-        while (innermostException.InnerException is not null)
-        {
-            innermostException = innermostException.InnerException;
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("*.0.0.1")]
+    [InlineData("*.169.254")]
+    [InlineData("")]
+    public void CreateThrowsArgumentExceptionForInvalidAllowedHostnameInOptions(string entry)
+    {
+        var options = new SsrfOptions { AllowedHostnames = [entry] };
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => Security.SsrfSocketsHttpHandlerFactory.Create(options));
+        Assert.Equal("options", ex.ParamName);
+    }
 
-            if (innermostException is SsrfException)
-            {
-                break;
-            }
-        }
-
-        Assert.IsType<SsrfException>(innermostException);
-        Assert.Equal(uri, ((SsrfException)ex.InnerException!).Uri!.ToString());
+    [Fact]
+    public void CreateDoesNotThrowForValidAllowedHostnames()
+    {
+        using SocketsHttpHandler handler = Security.SsrfSocketsHttpHandlerFactory.Create(
+            allowedHostnames: ["example.com", "*.example.com", "*.xn--p1ai", "co.uk"]);
+        Assert.NotNull(handler);
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "publicReleaseRefSpec": [
         "^refs\/heads\/main\/.*$"
     ],

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "5.3.0",
+    "version": "5.3.0-prerelease",
     "publicReleaseRefSpec": [
         "^refs\/heads\/main\/.*$"
     ],


### PR DESCRIPTION
* Skip allowedHostname checks for IP literal hosts, as they're not a host name.
* Add verification to allowedHostnames to ensure they don't contain any IP literals, and throw an exception if they do.
* Fix IPv6 proxy detection to check for IPv6 literals in the proxy address, not just hostnames that resolve to IPv6 addresses.
* Add documentation warnings to configuration for hostnames
* Add documentation warnings about TOCTOU warning to `Ssrf.IsUnsafe`