### PR TITLE
Optimize per-connection IP safety checks

### DIFF
--- a/src/idunno.Security.Ssrf/CommonFunctions.cs
+++ b/src/idunno.Security.Ssrf/CommonFunctions.cs
@@ -281,12 +281,10 @@ internal static class CommonFunctions
                 Log.CheckBypassedForIPAddressAsItIsInSafeIpAddresses(logger, uri, ipAddress);
                 safeResolvedIPAddresses.Add(ipAddress);
             }
-            else if (!Ssrf.IsUnsafeIpAddress(
+            else if (!Ssrf.IsUnsafeNormalizedIpAddress(
                 ipAddress: normalizedIPAddress,
                 additionalUnsafeIPNetworks: additionalUnsafeIPNetworks,
                 additionalUnsafeIPAddresses: additionalUnsafeIPAddresses,
-                safeIPNetworks: safeIPNetworks,
-                safeIPAddresses: safeIPAddresses,
                 allowLoopback: allowLoopback,
                 metrics: metrics))
             {
@@ -311,6 +309,14 @@ internal static class CommonFunctions
             Log.SomeResolvedIpAddressesUnsafe(logger, uri);
             metrics?.IncrementUnsafeIPAddress(1, "some_resolved_addresses_unsafe");
             throw new SsrfException(uri, $"Connection blocked as some resolved addresses for {uri.Host} are unsafe.");
+        }
+
+        // When every resolved address passed the safety checks no filtering occurred, so the safe list is
+        // identical to the resolved list. Return the original array directly to avoid allocating a second
+        // array from the list.
+        if (safeResolvedIPAddresses.Count == resolvedIpAddresses.Length)
+        {
+            return resolvedIpAddresses;
         }
 
         return [.. safeResolvedIPAddresses];

--- a/src/idunno.Security.Ssrf/IPAddressExtensions.cs
+++ b/src/idunno.Security.Ssrf/IPAddressExtensions.cs
@@ -337,13 +337,11 @@ public static class IPAddressExtensions
                 bool succeeded = ipAddress.TryWriteBytes(bytes, out _);
                 Debug.Assert(succeeded);
 
-                ReadOnlySpan<byte> ipV4Bytes =
-                [
-                    (byte)~bytes[12],
-                    (byte)~bytes[13],
-                    (byte)~bytes[14],
-                    (byte)~bytes[15],
-                ];
+                Span<byte> ipV4Bytes = stackalloc byte[4];
+                ipV4Bytes[0] = (byte)~bytes[12];
+                ipV4Bytes[1] = (byte)~bytes[13];
+                ipV4Bytes[2] = (byte)~bytes[14];
+                ipV4Bytes[3] = (byte)~bytes[15];
 
                 return new IPAddress(ipV4Bytes);
             }

--- a/src/idunno.Security.Ssrf/IPAddressExtensions.cs
+++ b/src/idunno.Security.Ssrf/IPAddressExtensions.cs
@@ -295,50 +295,88 @@ public static class IPAddressExtensions
         /// </remarks>
         public IPAddress NormalizeToIPv4()
         {
-            if (ipAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+            if (ipAddress.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6)
             {
-                // Normalize IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1)
-                if (ipAddress.IsIPv4MappedToIPv6)
-                {
-                    return ipAddress.MapToIPv4();
-                }
+                return ipAddress;
+            }
 
-                // Normalize IPv4-compatible IPv6 addresses (e.g. ::192.0.2.1)
-                if (ipAddress.IsIPv4CompatibleIPv6)
-                {
-                    return ipAddress.MapIPv6CompatibleToIPv4();
-                }
+            // Normalize IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1)
+            if (ipAddress.IsIPv4MappedToIPv6)
+            {
+                return ipAddress.MapToIPv4();
+            }
 
-                // Normalize 6:4 addresses (e.g. 2002:c000:0201::1)
-                // This may also catch an overlapping ISATAP address (e.g. 2002:c000:022a::5efe:0a00:0001), but that's not a problem since it will normalize to an unsafe IPv4 address anyway.
-                if (ipAddress.Is6to4)
-                {
-                    return ipAddress.Map6to4ToIPv4();
-                }
+            // Detection below uses the authoritative Is* members. Once a form is detected the embedded
+            // IPv4 address is sliced directly from a single byte serialization, rather than calling the
+            // corresponding Map* helper, each of which would re-run its own Is* detection and serialize
+            // the address a second time.
 
-                // Normalize Teredo addresses (e.g. 2001::) before ISATAP, because an attacker-crafted Teredo address
-                // (2001:0000::/32) can coincidentally match the ISATAP byte pattern (bytes 8-11 == 00-00-5E-FE
-                // or 02-00-5E-FE). Checking Teredo first ensures the Teredo-embedded client IPv4 is evaluated
-                // rather than an attacker-controlled ISATAP interpretation of the same bytes.
-                if (ipAddress.IsIPv6Teredo)
-                {
-                    return ipAddress.MapTeredoToIPv4();
-                }
+            // Normalize IPv4-compatible IPv6 addresses (e.g. ::192.0.2.1)
+            if (ipAddress.IsIPv4CompatibleIPv6)
+            {
+                return SliceEmbeddedIPv4(ipAddress, start: 12);
+            }
 
-                // Normalize ISATAP addresses (e.g. 2001:db8::5efe:)
-                if (ipAddress.IsISATAP)
-                {
-                    return ipAddress.MapISATAPToIPv4();
-                }
+            // Normalize 6:4 addresses (e.g. 2002:c000:0201::1)
+            // This may also catch an overlapping ISATAP address (e.g. 2002:c000:022a::5efe:0a00:0001), but that's not a problem since it will normalize to an unsafe IPv4 address anyway.
+            if (ipAddress.Is6to4)
+            {
+                return SliceEmbeddedIPv4(ipAddress, start: 2);
+            }
 
-                // Normalize NAT64 addresses (e.g. 64:ff9b::)
-                if (ipAddress.IsNAT64)
-                {
-                    return ipAddress.MapNAT64ToIPv4();
-                }
+            // Normalize Teredo addresses (e.g. 2001::) before ISATAP, because an attacker-crafted Teredo address
+            // (2001:0000::/32) can coincidentally match the ISATAP byte pattern (bytes 8-11 == 00-00-5E-FE
+            // or 02-00-5E-FE). Checking Teredo first ensures the Teredo-embedded client IPv4 is evaluated
+            // rather than an attacker-controlled ISATAP interpretation of the same bytes.
+            if (ipAddress.IsIPv6Teredo)
+            {
+                Span<byte> bytes = stackalloc byte[16];
+
+                // TryWriteBytes only fails if the buffer is too small, i.e. only if the span passed in is
+                // smaller than 16 bytes, so this will never fail.
+                bool succeeded = ipAddress.TryWriteBytes(bytes, out _);
+                Debug.Assert(succeeded);
+
+                ReadOnlySpan<byte> ipV4Bytes =
+                [
+                    (byte)~bytes[12],
+                    (byte)~bytes[13],
+                    (byte)~bytes[14],
+                    (byte)~bytes[15],
+                ];
+
+                return new IPAddress(ipV4Bytes);
+            }
+
+            // Normalize ISATAP addresses (e.g. 2001:db8::5efe:)
+            if (ipAddress.IsISATAP)
+            {
+                return SliceEmbeddedIPv4(ipAddress, start: 12);
+            }
+
+            // Normalize NAT64 addresses (e.g. 64:ff9b::)
+            if (ipAddress.IsNAT64)
+            {
+                return SliceEmbeddedIPv4(ipAddress, start: 12);
             }
 
             return ipAddress;
         }
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="ipAddress"/> once and returns the four embedded IPv4 bytes starting at
+    /// <paramref name="start"/> as an <see cref="IPAddress"/>.
+    /// </summary>
+    private static IPAddress SliceEmbeddedIPv4(IPAddress ipAddress, int start)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+
+        // TryWriteBytes only fails if the buffer is too small, i.e. only if the span passed in is
+        // smaller than 16 bytes, so this will never fail.
+        bool succeeded = ipAddress.TryWriteBytes(bytes, out _);
+        Debug.Assert(succeeded);
+
+        return new IPAddress(bytes.Slice(start, 4));
     }
 }

--- a/src/idunno.Security.Ssrf/Ssrf.cs
+++ b/src/idunno.Security.Ssrf/Ssrf.cs
@@ -249,6 +249,32 @@ public static class Ssrf
             }
         }
 
+        return IsUnsafeNormalizedIpAddress(
+            ipAddress: ipAddress,
+            additionalUnsafeIPNetworks: additionalUnsafeIPNetworks,
+            additionalUnsafeIPAddresses: additionalUnsafeIPAddresses,
+            allowLoopback: allowLoopback,
+            metrics: metrics);
+    }
+
+    /// <summary>
+    /// Evaluates an already-normalized <paramref name="ipAddress"/> against the unsafe checks, skipping both the
+    /// <see cref="IPAddressExtensions.NormalizeToIPv4(IPAddress)"/> step and the safe-list checks.
+    /// </summary>
+    /// <remarks>
+    /// <para>Callers must pass an address that has already been normalized via
+    /// <see cref="IPAddressExtensions.NormalizeToIPv4(IPAddress)"/> and must have already confirmed the address is
+    /// not present in any safe address or safe network list. This exists to avoid redundantly re-normalizing and
+    /// re-scanning the safe lists on the per-connection resolution hot path, where those checks have already run.</para>
+    /// </remarks>
+    [SuppressMessage("Minor Code Smell", "S3267:Loops should be simplified with \"LINQ\" expressions", Justification = "Avoids delegate allocation on hot path.")]
+    internal static bool IsUnsafeNormalizedIpAddress(
+        IPAddress ipAddress,
+        ICollection<IPNetwork>? additionalUnsafeIPNetworks,
+        ICollection<IPAddress>? additionalUnsafeIPAddresses,
+        bool allowLoopback,
+        SsrfMetrics? metrics)
+    {
         // Allow override to consider localhost addresses as safe
         if (allowLoopback && IPAddress.IsLoopback(ipAddress))
         {

--- a/src/idunno.Security.Ssrf/SsrfMetrics.cs
+++ b/src/idunno.Security.Ssrf/SsrfMetrics.cs
@@ -18,6 +18,15 @@ public sealed class SsrfMetrics
     private const string ReasonTagName = "reason";
     private const string ValueTagName = "value";
 
+    // Precompute the counter names once. These are derived from the meter name and were previously
+    // recomputed (three ToLowerInvariant calls plus three string interpolations) on every handler
+    // construction inside CreateCounters.
+    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Guidelines suggest all lower case.")]
+    private static readonly string s_meterNameLowerInvariant = MeterName.ToLowerInvariant();
+    private static readonly string s_blockedRequestsCounterName = $"{s_meterNameLowerInvariant}.blocked.requests.total";
+    private static readonly string s_unsafeUriCounterName = $"{s_meterNameLowerInvariant}.unsafe.uri.total";
+    private static readonly string s_unsafeIPAddressCounterName = $"{s_meterNameLowerInvariant}.unsafe.ip_address.total";
+
     private Counter<long> _blockedRequests;
     private Counter<long> _unsafeUri;
     private Counter<long> _unsafeIPAddress;
@@ -74,21 +83,20 @@ public sealed class SsrfMetrics
     }
 
     [MemberNotNull(nameof(_blockedRequests), nameof(_unsafeUri), nameof(_unsafeIPAddress))]
-    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Guidelines suggest all lower case.")]
     private void CreateCounters(Meter meter)
     {
         _blockedRequests = meter.CreateCounter<long>(
-            name: $"{MeterName.ToLowerInvariant()}.blocked.requests.total",
+            name: s_blockedRequestsCounterName,
             description: "Number of requests blocked due to SSRF detection.",
             unit: "{requests}");
 
         _unsafeUri = meter.CreateCounter<long>(
-            name: $"{MeterName.ToLowerInvariant()}.unsafe.uri.total",
+            name: s_unsafeUriCounterName,
             description: "Number of unsafe URIs detected.",
             unit: "{uris}");
 
         _unsafeIPAddress = meter.CreateCounter<long>(
-            name: $"{MeterName.ToLowerInvariant()}.unsafe.ip_address.total",
+            name: s_unsafeIPAddressCounterName,
             description: "Number of unsafe IP addresses detected.",
             unit: "{ip_addresses}");
     }


### PR DESCRIPTION
## Why

The per-connection DNS validation path runs on every outgoing request (`ConnectCallback` / handler `SendAsync`). Reviewing it surfaced several spots doing redundant work with no behavioral benefit. This PR removes that redundancy without changing any safe/unsafe decisions.

## What changed

**1. Remove redundant re-normalization and double safe-list scan (hot path).**
`ReduceResolvedIPAddressesToSafeIPAddresses` already normalizes each resolved address (`NormalizeToIPv4`) and checks it against the safe address / safe network lists. It then called `Ssrf.IsUnsafeIpAddress`, which re-normalized the same address and re-scanned the same safe lists. Because that branch is only reached when the address is not in a safe list, those inner scans were guaranteed to miss on every request. The post-safe-list logic is now extracted into a new internal `IsUnsafeNormalizedIpAddress`, which the hot path calls directly, saving one `NormalizeToIPv4` pass and two collection scans per resolved IP. The public `IsUnsafeIpAddress` keeps identical behavior by normalizing, running the safe-list checks, then delegating to the new method (no duplicated logic).

**2. Avoid an extra array allocation when nothing is filtered.**
When every resolved address passes the safety checks (the common case), the method now returns the original resolved array directly instead of building a `List<IPAddress>` and copying it into a new array via `[.. list]`.

**3. Slice the embedded IPv4 once in `NormalizeToIPv4`.**
Once a transition form (IPv4-compatible, 6to4, Teredo, ISATAP, NAT64) is detected, the embedded IPv4 address is now sliced directly from a single byte serialization instead of calling the `Map*` helpers, each of which re-ran its own `Is*` detection and serialized the address a second time. Detection still goes through the authoritative `Is*` members, so scope-id semantics for `IsIPv4CompatibleIPv6` and the RFC prefix checks are unchanged.

**4. Precompute metric counter names.**
`SsrfMetrics` computed its three counter names by calling `MeterName.ToLowerInvariant()` three times and interpolating three strings on every construction (once per handler build). Those names are now computed once at type initialization.

## Notes for reviewers

All four changes are behavior-preserving: identical ordering, identical safe/unsafe decisions, identical metric names and values emitted. For change 3, detection was deliberately left on the existing public `Is*`/`IPNetwork.Contains` members rather than reimplemented against the byte span, to avoid duplicating security-critical prefix logic and to preserve the documented scope-aware `::`/`::1` handling. The `Map*` helpers remain part of the public API and are unchanged.

All 931 tests pass on net8.0, net9.0, and net10.0.